### PR TITLE
Drop use of CustomTabsHelper

### DIFF
--- a/app/src/main/java/dev/msfjarvis/lobsters/urllauncher/UrlLauncherImpl.kt
+++ b/app/src/main/java/dev/msfjarvis/lobsters/urllauncher/UrlLauncherImpl.kt
@@ -3,8 +3,6 @@ package dev.msfjarvis.lobsters.urllauncher
 import android.content.Context
 import android.net.Uri
 import androidx.browser.customtabs.CustomTabsIntent
-import saschpe.android.customtabs.CustomTabsHelper
-import saschpe.android.customtabs.WebViewFallback
 
 class UrlLauncherImpl(private val context: Context) : UrlLauncher {
   override fun launch(url: String) {
@@ -12,11 +10,6 @@ class UrlLauncherImpl(private val context: Context) : UrlLauncher {
       .setShareState(CustomTabsIntent.SHARE_STATE_ON)
       .setShowTitle(true)
       .build()
-    CustomTabsHelper.addKeepAliveExtra(context, customTabsIntent.intent)
-    CustomTabsHelper.openCustomTab(
-      context, customTabsIntent,
-      Uri.parse(url),
-      WebViewFallback()
-    )
+    customTabsIntent.launchUrl(context, Uri.parse(url))
   }
 }


### PR DESCRIPTION
It's doing either a package lookup or something like that which is causing the WebView fallback to be triggered on Android 11, so I'm switching to the AndroidX stuff until I can look at the library source