### PR TITLE
Fallback to comments if post has no URL

### DIFF
--- a/app/src/main/java/dev/msfjarvis/lobsters/MainActivity.kt
+++ b/app/src/main/java/dev/msfjarvis/lobsters/MainActivity.kt
@@ -79,7 +79,7 @@ fun LobstersApp(
           }
           LobstersItem(
             item,
-            linkOpenAction = { post -> urlLauncher.launch(post.url) },
+            linkOpenAction = { post -> urlLauncher.launch(post.url.ifEmpty { post.commentsUrl }) },
             commentOpenAction = { post -> urlLauncher.launch(post.commentsUrl) },
           )
         }


### PR DESCRIPTION
Some posts are simply discussions and contain no URLs, so we're going to use their comments URL for both click actions.
