### PR TITLE
Update all actions and pin to SHA1 hashes

### DIFF
--- a/.github/workflows/automerge.yml
+++ b/.github/workflows/automerge.yml
@@ -22,8 +22,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: automerge
-        uses: "pascalgn/automerge-action@v0.11.0"
+        uses: pascalgn/automerge-action@88480459fd3771b8f4c7e68bb9b677b5e1e48f36
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
-          UPDATE_RETRIES: 10
-          UPDATE_RETRY_SLEEP: 60000
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          MERGE_RETRIES: 10
+          MERGE_RETRY_SLEEP: 60000

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Check if relevant files have changed
-      uses: actions/github-script@0.9.0
+      uses: actions/github-script@28e5ebafd79744f2a15dd15e742233b068e0f762
       id: service-changed
       with:
         result-encoding: string
@@ -23,20 +23,20 @@ jobs:
 
     - name: Checkout repository
       if: ${{ steps.service-changed.outputs.result == 'true' }}
-      uses: actions/checkout@v2
+      uses: actions/checkout@c952173edf28a2bd22e1a4926590c1ac39630461
 
     - name: Copy CI gradle.properties
       if: ${{ steps.service-changed.outputs.result == 'true' }}
       run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
-    - uses: burrunan/gradle-cache-action@v1
+    - uses: burrunan/gradle-cache-action@61348edb3ed90fd775bd9738ac6535163f5b8c4b
       name: Run unit tests
       with:
         arguments: testDebug
 
     - name: (Fail-only) upload test report
       if: failure()
-      uses: actions/upload-artifact@v2
+      uses: actions/upload-artifact@27bce4eee761b5bc643f46a8dfb41b430c8d05f6
       with:
           name: Test report
           path: app/build/reports

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -29,7 +29,7 @@ jobs:
       if: ${{ steps.service-changed.outputs.result == 'true' }}
       run: mkdir -p ~/.gradle ; cp .github/ci-gradle.properties ~/.gradle/gradle.properties
 
-    - uses: burrunan/gradle-cache-action@61348edb3ed90fd775bd9738ac6535163f5b8c4b
+    - uses: burrunan/gradle-cache-action@v1
       name: Run unit tests
       with:
         arguments: testDebug


### PR DESCRIPTION
Tags can be force-pushed and be replaced with malicious versions. Switching to exact hashes alleviates that problem, offering greater security and control over workflows