### PR TITLE
Update coroutines and AGP

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
         browser_version = "1.3.0-alpha06"
         compose_version = "1.0.0-alpha05"
         core_version = "1.5.0-alpha04"
-        coroutines_version = "1.3.9"
+        coroutines_version = "1.4.0"
         customtabs_version = "3.0.2"
         dagger_version = "2.29.1"
         desugar_version = "1.0.10"

--- a/build.gradle
+++ b/build.gradle
@@ -3,7 +3,7 @@ buildscript {
     ext {
         accompanist_version = "0.3.1"
         activity_version = "1.2.0-beta01"
-        agp_version = "4.2.0-alpha14"
+        agp_version = "4.2.0-alpha15"
         appcompat_version = "1.3.0-alpha02"
         browser_version = "1.3.0-alpha06"
         compose_version = "1.0.0-alpha05"

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,8 +21,7 @@ kapt.incremental.apt=true
 kapt.include.compile.classpath=false
 
 # Use R8 instead of ProGuard for code shrinking.
-# R8 Full Mode be nasty
-# android.enableR8.fullMode=true
+android.enableR8.fullMode=true
 
 # Enable AndroidX
 android.useAndroidX=true


### PR DESCRIPTION
Updates AGP to 4.2.0-alpha15 that resolves the [AGP inlining bug](https://msfjarvis.github.io/notes/r8-inlining-bugs.html) and to coroutines 1.4.0 that brings performance improvements.
