### PR TITLE
Fix Jetpack Compose link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # compose-lobsters
 
-Android app for read-only access to [lobste.rs](https://lobste.rs) community, built with [Jetpack Compose](https://https://developer.android.com/jetpack/compose).
+Android app for read-only access to [lobste.rs](https://lobste.rs) community, built with [Jetpack Compose](https://developer.android.com/jetpack/compose).


### PR DESCRIPTION
The current link does not resolve because of the double `https://`