### PR TITLE
Update AGP flags

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ org.gradle.parallel=true
 org.gradle.configureondemand=true
 org.gradle.caching=true
 
-# Enabling filesystem watching
+# Enable filesystem watching
 org.gradle.vfs.watch=true
 
 # Enable Kotlin incremental compilation
@@ -31,6 +31,9 @@ android.useAndroidX=true
 # transitive dependency references.
 android.nonTransitiveRClass=true
 
+# Generate compile-time only R class for app modules.
+android.enableAppCompileTimeRClass=true
+
 # Only keep the single relevant constructor for types mentioned in XML files
 # instead of using a parameter wildcard which keeps them all.
 android.useMinimalKeepRules=true
@@ -44,6 +47,7 @@ android.defaults.buildfeatures.aidl=false
 android.defaults.buildfeatures.renderscript=false
 android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
+android.library.defaults.buildfeatures.androidresources=false
 
 # Disable warnings about unsupported features, we know what we're doing
 android.suppressUnsupportedOptionWarnings=android.enableR8.fullMode,android.enableResourceOptimizations,android.nonTransitiveRClass,android.suppressUnsupportedOptionWarnings

--- a/lobsters-api/build.gradle
+++ b/lobsters-api/build.gradle
@@ -2,6 +2,8 @@ plugins {
   id 'kotlin-kapt'
 }
 
+android.buildFeatures.androidResources = true
+
 dependencies {
   implementation project(":model")
   implementation "com.squareup.retrofit2:retrofit:$retrofit_version"


### PR DESCRIPTION
Make R class compile-time only for app modules, and disable Android resources for library modules by default