### PR TITLE
Add more tests for Lobsters API and fix okhttp version

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+cec0e1bbcb7eec6c8eb90807c105cbeab9c01c6c # Reformatted Gradle build files with 2 space indent
+c3cead59934c8c5221694940fc83be57fa50ac20 # Moved data module into app

--- a/build.gradle
+++ b/build.gradle
@@ -20,7 +20,7 @@ buildscript {
     material_version = "1.3.0-alpha03"
     moshi_version = "1.11.0"
     nav_compose_version = "1.0.0-alpha01"
-    okhttp_version = "4.10.0-RC1"
+    okhttp_version = "3.14.9"
     retrofit_version = "2.9.0"
     room_version = "2.3.0-alpha03"
     roomigrant_version = "0.2.0"

--- a/lobsters-api/src/test/java/dev/msfjarvis/lobsters/api/LobstersApiTest.kt
+++ b/lobsters-api/src/test/java/dev/msfjarvis/lobsters/api/LobstersApiTest.kt
@@ -7,6 +7,7 @@ import okhttp3.mockwebserver.MockWebServer
 import okhttp3.mockwebserver.RecordedRequest
 import org.junit.After
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 
@@ -29,6 +30,24 @@ class LobstersApiTest {
   fun `api gets correct number of items`() = runBlocking {
     val posts = apiClient.getHottestPosts(1)
     assertEquals(25, posts.size)
+  }
+
+  @Test
+  fun `no moderator posts in test data`() = runBlocking {
+    val posts = apiClient.getHottestPosts(1)
+    val moderatorPosts = posts.asSequence()
+      .filter { it.submitterUser.isModerator }
+      .toSet()
+    assertTrue(moderatorPosts.isEmpty())
+  }
+
+  @Test
+  fun `posts with no urls`() = runBlocking {
+    val posts = apiClient.getHottestPosts(1)
+    val commentsOnlyPosts = posts.asSequence()
+      .filter { it.url.isEmpty() }
+      .toSet()
+    assertEquals(2, commentsOnlyPosts.size)
   }
 
   @After


### PR DESCRIPTION
Downgrades OkHttp back to 3.14.9 because that's what Retrofit uses and using a higher version results in test failures for me when executed through the IDE. Also adds a couple more tests for the API data, and adds a `.git-blame-ignore-revs` file to skip some noisy commits that make `git-blame` that much useless.

bors r+
