### PR TITLE
Follow up on Gradle build rewrite

### DIFF
--- a/lobsters-api/build.gradle.kts
+++ b/lobsters-api/build.gradle.kts
@@ -8,6 +8,7 @@ plugins {
 dependencies {
   implementation(project(":model"))
   implementation(Dependencies.Kotlin.Serialization.json)
+  implementation(Dependencies.ThirdParty.Retrofit.lib)
   implementation(Dependencies.ThirdParty.retrofitSerialization)
   testImplementation(Dependencies.Testing.junit)
   testImplementation(Dependencies.Kotlin.Coroutines.core)

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,4 +1,0 @@
-rootProject.name = "lobste.rs"
-include ':app'
-include ':lobsters-api'
-include ':model'

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,0 +1,3 @@
+rootProject.name = "lobste.rs"
+include(":app", ":lobsters-api", ":model")
+enableFeaturePreview("GRADLE_METADATA")


### PR DESCRIPTION
Adds back a dependency that was accidentally removed, and converts `settings.gradle` to Kotlin

bors r+