### PR TITLE
Tweak ripple bounds and adjust R8 and AGP options

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -1,1 +1,3 @@
 -keepattributes *Annotation*, EnclosingMethod, InnerClasses
+-dontwarn org.jetbrains.kotlin.**
+-dontwarn androidx.compose.animation.tooling.ComposeAnimation

--- a/app/src/main/java/dev/msfjarvis/lobsters/ui/posts/HottestPosts.kt
+++ b/app/src/main/java/dev/msfjarvis/lobsters/ui/posts/HottestPosts.kt
@@ -1,6 +1,5 @@
 package dev.msfjarvis.lobsters.ui.posts
 
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.Composable
@@ -26,7 +25,7 @@ fun HottestPosts(
   } else {
     LazyColumn(
       state = listState,
-      modifier = Modifier.padding(horizontal = 8.dp).then(modifier),
+      modifier = Modifier.then(modifier),
     ) {
       items(posts) { item ->
         if (item != null) {

--- a/app/src/main/java/dev/msfjarvis/lobsters/ui/posts/LobstersItem.kt
+++ b/app/src/main/java/dev/msfjarvis/lobsters/ui/posts/LobstersItem.kt
@@ -70,7 +70,7 @@ fun LobstersItem(
       ),
   ) {
     ConstraintLayout(
-      modifier = Modifier.padding(start = 4.dp, end = 4.dp),
+      modifier = Modifier.padding(start = 12.dp, end = 12.dp),
     ) {
       val (title, tags, avatar, submitter, saveButton) = createRefs()
       Text(

--- a/app/src/main/java/dev/msfjarvis/lobsters/ui/posts/SavedPosts.kt
+++ b/app/src/main/java/dev/msfjarvis/lobsters/ui/posts/SavedPosts.kt
@@ -1,6 +1,5 @@
 package dev.msfjarvis.lobsters.ui.posts
 
-import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.runtime.Composable
@@ -23,7 +22,7 @@ fun SavedPosts(
   } else {
     LazyColumn(
       state = listState,
-      modifier = Modifier.padding(horizontal = 8.dp).then(modifier)
+      modifier = Modifier.then(modifier)
     ) {
       items(posts) { item ->
         LobstersItem(

--- a/gradle.properties
+++ b/gradle.properties
@@ -47,6 +47,3 @@ android.defaults.buildfeatures.renderscript=false
 android.defaults.buildfeatures.resvalues=false
 android.defaults.buildfeatures.shaders=false
 android.library.defaults.buildfeatures.androidresources=false
-
-# Disable warnings about unsupported features, we know what we're doing
-android.suppressUnsupportedOptionWarnings=android.enableR8.fullMode,android.enableResourceOptimizations,android.nonTransitiveRClass,android.suppressUnsupportedOptionWarnings


### PR DESCRIPTION

Setting padding in individual lists caused the ripple from LobstersItem to not draw to the edges, which was annoying to look at. Now we set the padding in LobstersItem itself and skip doing so in the individual list composables.

bors r+