### PR TITLE
Shorten Gradle project name

### DIFF
--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,3 +1,3 @@
-rootProject.name = "Claw for lobste.rs"
+rootProject.name = "Claw"
 include(":app", ":api", ":database")
 enableFeaturePreview("GRADLE_METADATA")


### PR DESCRIPTION
Just takes less horizontal space in the tree so what the hell

bors r+