### PR TITLE
Only run CI on reviewed pull requests

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -1,14 +1,11 @@
 name: CI
 
-"on":
+on:
   push:
     branches:
       - staging
       - trying
       - develop
-  pull_request:
-    branches:
-      - "**"
 
 jobs:
   test-pr:


### PR DESCRIPTION
Saves execution time and is just a safer option
bors r+