### PR TITLE
Enable Auto Backup for database files

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,7 +12,8 @@
     android:label="@string/app_name"
     android:roundIcon="@mipmap/ic_launcher"
     android:supportsRtl="true"
-    android:theme="@style/Theme.AppCompat.DayNight">
+    android:theme="@style/Theme.AppCompat.DayNight"
+    android:fullBackupContent="@xml/full_backup_content">
     <activity
       android:name=".ui.main.MainActivity"
       android:label="@string/app_name"

--- a/app/src/main/res/xml/full_backup_content.xml
+++ b/app/src/main/res/xml/full_backup_content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+  <!-- Backup SQLDelight generated databases so that saved posts can be restored -->
+  <include domain="root" path="databases" />
+</full-backup-content>


### PR DESCRIPTION
We persist saved posts in our SQLDelight database and while Android has been automatically doing backups, this makes it more explicit
bors r+