### PR TITLE
Fix AVD name in emulator bootup script

### DIFF
--- a/scripts/boot_emulator.sh
+++ b/scripts/boot_emulator.sh
@@ -16,7 +16,7 @@ API_LEVEL="${ANDROID_API_LEVEL:-30}"
 
 echo no | "${ANDROID_SDK_ROOT}"/cmdline-tools/latest/bin/avdmanager create avd \
   --force \
-  -n Pixel_XL_API_30 \
+  -n "Pixel_XL_API_${API_LEVEL}" \
   --abi 'google_apis/x86' \
   --package "system-images;android-${API_LEVEL};google_apis;x86" \
   --device 'pixel_xl'


### PR DESCRIPTION
It didn't fail in this repo because we stick to API 30 only but it's good to fix it anyway

bors r+