### PR TITLE
build: remove KotlinX Bintray repository

### DIFF
--- a/buildSrc/src/main/java/BaseProjectConfig.kt
+++ b/buildSrc/src/main/java/BaseProjectConfig.kt
@@ -34,15 +34,8 @@ internal fun Project.configureForRootProject() {
 /** Configure all projects including the root project */
 internal fun Project.configureForAllProjects() {
   repositories {
-    google()
     mavenCentral()
-    maven("https://dl.bintray.com/kotlin/kotlinx") {
-      name = "KotlinX Bintray"
-      content {
-        includeModule("org.jetbrains.kotlinx", "kotlinx-collections-immutable")
-        includeModule("org.jetbrains.kotlinx", "kotlinx-collections-immutable-jvm")
-      }
-    }
+    google()
   }
   tasks.withType<KotlinCompile> {
     kotlinOptions {


### PR DESCRIPTION
0.4.0-build182 upgraded kotlinx-collections-immutable to a version that no longer requires this repository

Ref: https://github.com/JetBrains/compose-jb/commit/8c8b4147abd0b697afd5b4ac216e426328054411