### PR TITLE
Bump to AGP 7.0.0-alpha15

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,5 +1,3 @@
-import com.android.build.gradle.internal.api.BaseVariantOutputImpl
-
 plugins {
   id("com.android.application")
   kotlin("android")
@@ -16,11 +14,6 @@ android {
   defaultConfig {
     applicationId = "dev.msfjarvis.lobsters"
     testInstrumentationRunner = "com.karumi.shot.ShotTestRunner"
-  }
-  applicationVariants.all {
-    outputs.all {
-      (this as BaseVariantOutputImpl).outputFileName = "Claw-$versionName.apk"
-    }
   }
 }
 

--- a/buildSrc/build.gradle.kts
+++ b/buildSrc/build.gradle.kts
@@ -24,7 +24,7 @@ gradlePlugin {
 }
 
 dependencies {
-  implementation("com.android.tools.build:gradle:7.0.0-alpha14")
+  implementation("com.android.tools.build:gradle:7.0.0-alpha15")
   implementation("com.google.dagger:hilt-android-gradle-plugin:2.35.1")
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.4.32")
   implementation("com.google.devtools.ksp:symbol-processing-gradle-plugin:1.4.32-1.0.0-alpha08")

--- a/buildSrc/src/main/java/BaseProjectConfig.kt
+++ b/buildSrc/src/main/java/BaseProjectConfig.kt
@@ -78,7 +78,7 @@ internal fun BaseAppModuleExtension.configureAndroidApplicationOptions(project: 
   buildTypes {
     named("release") {
       isMinifyEnabled = !minifySwitch.isPresent
-      setProguardFiles(listOf("proguard-android-optimize.txt", "proguard-rules.pro"))
+      proguardFiles("proguard-android-optimize.txt", "proguard-rules.pro")
     }
     named("debug") {
       applicationIdSuffix = ".debug"
@@ -94,8 +94,8 @@ internal fun TestedExtension.configureCommonAndroidOptions() {
   compileSdkVersion(30)
 
   defaultConfig {
-    minSdkVersion(23)
-    targetSdkVersion(30)
+    minSdk = 23
+    targetSdk = 23
   }
 
   packagingOptions.resources.excludes.addAll(

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,7 +15,7 @@ sqldelight = "1.5.0"
 
 [libraries]
 # buildSrc dependencies, they are not used from here for now so manually update buildSrc/build.gradle.kts as well
-androidGradlePlugin = "com.android.tools.build:gradle:7.0.0-alpha14"
+androidGradlePlugin = "com.android.tools.build:gradle:7.0.0-alpha15"
 composeGradlePlugin = { module = "org.jetbrains.compose:compose-gradle-plugin", version.ref = "jb_compose" }
 hiltGradlePlugin = { module = "com.google.dagger:hilt-android-gradle-plugin", version.ref = "dagger_hilt" }
 jsemverGradlePlugin = "com.github.zafarkhaja:java-semver:0.9.0"

--- a/scripts/deploy-snapshot.sh
+++ b/scripts/deploy-snapshot.sh
@@ -3,11 +3,12 @@
 set -euo pipefail
 
 export SSHDIR="$HOME/.ssh"
+export SERVER_DEPLOY_STRING="$SSH_USERNAME@$SERVER_ADDRESS:$SERVER_DESTINATION"
+export VERSION_NAME="$(cat app/version.properties | grep versionName | cut -d '=' -f 2)"
 mkdir -p "$SSHDIR"
 echo "$ACTIONS_DEPLOY_KEY" > "$SSHDIR/key"
 chmod 600 "$SSHDIR/key"
-export SERVER_DEPLOY_STRING="$SSH_USERNAME@$SERVER_ADDRESS:$SERVER_DESTINATION"
 mkdir -p "$GITHUB_WORKSPACE/Claw"
-cp -v ./app/build/outputs/apk/release/*.apk "$GITHUB_WORKSPACE/Claw/"
+cp -v ./app/build/outputs/apk/release/app-release.apk "$GITHUB_WORKSPACE/Claw/Claw-${VERSION_NAME}.apk"
 cd "$GITHUB_WORKSPACE/Claw"
 rsync -ahvcr --omit-dir-times --progress --delete --no-o --no-g -e "ssh -i $SSHDIR/key -o StrictHostKeyChecking=no -p $SSH_PORT" . "$SERVER_DEPLOY_STRING"


### PR DESCRIPTION
Also adapts the snapshot deployment scripts for removal of variant output API.

bors r+
