### PR TITLE
Handle lobste.rs deeplinks in the app

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -62,7 +62,17 @@
         <data
           android:host="lobste.rs"
           android:scheme="https"
-          android:pathPrefix="/s/" />
+          android:pathPattern="/s/......"/>
+
+        <data
+          android:host="lobste.rs"
+          android:scheme="https"
+          android:pathPattern="/s/....../"/>
+
+        <data
+          android:host="lobste.rs"
+          android:scheme="https"
+          android:pathPattern="/s/....../...*"/>
       </intent-filter>
     </activity>
     <activity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -8,21 +8,62 @@
   <application
     android:name=".ClawApplication"
     android:allowBackup="true"
+    android:fullBackupContent="@xml/full_backup_content"
     android:icon="@mipmap/ic_launcher"
     android:label="@string/app_name"
     android:roundIcon="@mipmap/ic_launcher"
     android:supportsRtl="true"
-    android:theme="@style/Theme.AppCompat.DayNight"
-    android:fullBackupContent="@xml/full_backup_content">
+    android:theme="@style/Theme.AppCompat.DayNight">
     <activity
       android:name=".ui.main.MainActivity"
+      android:exported="true"
       android:label="@string/app_name"
-      android:theme="@style/Platform.Theme.Claw"
-      android:exported="true">
+      android:theme="@style/Platform.Theme.Claw">
       <intent-filter>
         <action android:name="android.intent.action.MAIN" />
 
         <category android:name="android.intent.category.LAUNCHER" />
+      </intent-filter>
+      <intent-filter android:label="@string/hottest_posts">
+        <action android:name="android.intent.action.VIEW" />
+
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+
+        <data
+          android:ssp="//lobste.rs"
+          android:scheme="https" />
+
+        <data
+          android:host="lobste.rs"
+          android:scheme="https"
+          android:path="/"/>
+      </intent-filter>
+
+      <intent-filter android:label="@string/newest_posts">
+        <action android:name="android.intent.action.VIEW" />
+
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+
+        <data
+          android:host="lobste.rs"
+          android:scheme="https"
+          android:pathPrefix="/recent" />
+      </intent-filter>
+
+
+      <intent-filter android:label="@string/open_comments">
+        <action android:name="android.intent.action.VIEW" />
+
+        <category android:name="android.intent.category.DEFAULT" />
+        <category android:name="android.intent.category.BROWSABLE" />
+
+        <data
+          android:host="lobste.rs"
+          android:scheme="https"
+          android:pathPrefix="/s/"
+          android:pathPattern="/.*/"/>
       </intent-filter>
     </activity>
     <activity

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -62,8 +62,7 @@
         <data
           android:host="lobste.rs"
           android:scheme="https"
-          android:pathPrefix="/s/"
-          android:pathPattern="/.*/"/>
+          android:pathPrefix="/s/" />
       </intent-filter>
     </activity>
     <activity

--- a/app/src/main/java/dev/msfjarvis/lobsters/ui/comments/Comments.kt
+++ b/app/src/main/java/dev/msfjarvis/lobsters/ui/comments/Comments.kt
@@ -100,7 +100,15 @@ private fun CommentsPageInternal(
               tween(durationMillis = AnimationDuration, easing = FastOutLinearInEasing),
           )
       ) {
-        FloatingActionButton(onClick = { urlLauncher.launch(details.commentsUrl) }) {
+        // Post links from lobste.rs are of the form $baseUrl/s/$postId/$postTitle
+        // Interestingly, lobste.rs does not actually care for the value of $postTitle, and will
+        // happily accept both a missing as well as a completely arbitrary $postTitle. We
+        // leverage this to create a new URL format which looks like
+        // $baseUrl/s/$postId/$postTitle/r,
+        // and does not trigger our deeplinks, instead opening in the custom tab as we want it to.
+        FloatingActionButton(
+          onClick = { urlLauncher.launch(details.commentsUrl.replaceAfterLast('/', "r")) }
+        ) {
           IconResource(
             resourceId = R.drawable.ic_reply_24dp,
             contentDescription = Strings.ReplyButtonContentDescription.get()

--- a/app/src/main/java/dev/msfjarvis/lobsters/ui/main/LobstersApp.kt
+++ b/app/src/main/java/dev/msfjarvis/lobsters/ui/main/LobstersApp.kt
@@ -24,6 +24,7 @@ import androidx.navigation.compose.currentBackStackEntryAsState
 import androidx.navigation.compose.navArgument
 import androidx.navigation.compose.navigate
 import androidx.navigation.compose.rememberNavController
+import androidx.navigation.navDeepLink
 import androidx.paging.LoadState
 import androidx.paging.compose.collectAsLazyPagingItems
 import dev.msfjarvis.lobsters.ui.comments.CommentsPage
@@ -89,7 +90,12 @@ fun LobstersApp() {
     },
   ) { innerPadding ->
     NavHost(navController, startDestination = Destination.startDestination.route) {
-      composable(Destination.Hottest.route) {
+      val uri = "https://lobste.rs"
+
+      composable(
+        route = Destination.Hottest.route,
+        deepLinks = listOf(navDeepLink { uriPattern = uri }, navDeepLink { uriPattern = "$uri/" })
+      ) {
         NetworkPosts(
           posts = hottestPosts,
           listState = hottestPostsListState,
@@ -99,7 +105,14 @@ fun LobstersApp() {
           viewComments = { navController.navigate("comments/$it") },
         )
       }
-      composable(Destination.Newest.route) {
+      composable(
+        route = Destination.Newest.route,
+        deepLinks =
+          listOf(
+            navDeepLink { uriPattern = "$uri/recent" },
+            navDeepLink { uriPattern = "$uri/recent/" }
+          )
+      ) {
         NetworkPosts(
           posts = newestPosts,
           listState = newestPostsListState,
@@ -119,8 +132,13 @@ fun LobstersApp() {
         )
       }
       composable(
-        Destination.Comments.route,
-        listOf(navArgument("postId") { type = NavType.StringType }),
+        route = Destination.Comments.route,
+        arguments = listOf(navArgument("postId") { type = NavType.StringType }),
+        deepLinks =
+          listOf(
+            navDeepLink { uriPattern = "$uri/s/{postId}/.*" },
+            navDeepLink { uriPattern = "$uri/s/{postId}" }
+          )
       ) { backStackEntry ->
         CommentsPage(
           postId = requireNotNull(backStackEntry.arguments?.getString("postId")),


### PR DESCRIPTION
Deeplink handling in Android is _interesting_.

Here's what is happening atm, 

```
<data
	android:ssp="//lobste.rs"
    android:scheme="https" />
```
Handles `https://lobste.rs`. We are using `ssp` here because using `host` without path `/` will match with all of the possible paths e.g, `https://lobste.rs/login` which we do not want.


```
<data
	android:host="lobste.rs"
    android:scheme="https"
    android:path="/"/>
```
Handles `https://lobste.rs/`


```
<data
	android:host="lobste.rs"
    android:scheme="https"
    android:pathPrefix="/recent" />
```
Handles `https://lobste.rs/recent` and `https://lobste.rs/recent/`


```
<data
	android:host="lobste.rs"
    android:scheme="https"
    android:pathPattern="/s/......" />
```
Handles `https://lobste.rs/nr9kzv`.

```
<data
	android:host="lobste.rs"
    android:scheme="https"
    android:pathPattern="/s/....../" />
```
Handles `https://lobste.rs/nr9kzv/`.

```
<data
	android:host="lobste.rs"
    android:scheme="https"
    android:pathPattern="/s/....../...*" />
```
Handles everything after `https://lobste.rs/s/nr9kzv/` except for a case where the `postTitle` is one character long. This one character string is used for the reply URL.