### PR TITLE
Add `Divider` composable in common module

### DIFF
--- a/android/src/main/kotlin/dev/msfjarvis/claw/android/ui/lists/DatabasePosts.kt
+++ b/android/src/main/kotlin/dev/msfjarvis/claw/android/ui/lists/DatabasePosts.kt
@@ -6,6 +6,7 @@ import androidx.compose.foundation.lazy.items
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import dev.msfjarvis.claw.common.posts.PostActions
+import dev.msfjarvis.claw.common.ui.Divider
 import dev.msfjarvis.claw.database.local.SavedPost
 
 @Composable
@@ -26,6 +27,8 @@ fun DatabasePosts(
         isSaved = isSaved,
         postActions = postActions,
       )
+
+      Divider()
     }
   }
 }

--- a/android/src/main/kotlin/dev/msfjarvis/claw/android/ui/lists/NetworkPosts.kt
+++ b/android/src/main/kotlin/dev/msfjarvis/claw/android/ui/lists/NetworkPosts.kt
@@ -2,13 +2,13 @@ package dev.msfjarvis.claw.android.ui.lists
 
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.LazyListState
-import androidx.compose.material.Divider
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.paging.compose.LazyPagingItems
 import androidx.paging.compose.items
 import dev.msfjarvis.claw.common.posts.PostActions
 import dev.msfjarvis.claw.common.posts.toDbModel
+import dev.msfjarvis.claw.common.ui.Divider
 import dev.msfjarvis.claw.database.local.SavedPost
 import dev.msfjarvis.claw.model.LobstersPost
 

--- a/common/src/commonMain/kotlin/dev/msfjarvis/claw/common/comments/CommentEntry.kt
+++ b/common/src/commonMain/kotlin/dev/msfjarvis/claw/common/comments/CommentEntry.kt
@@ -6,7 +6,6 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.material.Divider
 import androidx.compose.material.LocalContentColor
 import androidx.compose.material.LocalTextStyle
 import androidx.compose.material3.MaterialTheme
@@ -22,6 +21,7 @@ import com.halilibo.richtext.ui.material.MaterialRichText
 import dev.msfjarvis.claw.common.posts.PostDetails
 import dev.msfjarvis.claw.common.posts.Submitter
 import dev.msfjarvis.claw.common.posts.toDbModel
+import dev.msfjarvis.claw.common.ui.Divider
 import dev.msfjarvis.claw.model.Comment
 import dev.msfjarvis.claw.model.LobstersPostDetails
 
@@ -59,7 +59,7 @@ fun CommentEntry(
   comment: Comment,
 ) {
   val htmlConverter = LocalHTMLConverter.current
-  Divider(color = Color.Gray.copy(0.4f))
+  Divider()
   Row(modifier = Modifier.wrapContentHeight()) {
     Column(
       modifier =

--- a/common/src/commonMain/kotlin/dev/msfjarvis/claw/common/comments/CommentEntry.kt
+++ b/common/src/commonMain/kotlin/dev/msfjarvis/claw/common/comments/CommentEntry.kt
@@ -13,7 +13,6 @@ import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.CompositionLocalProvider
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import com.halilibo.richtext.markdown.Markdown
 import com.halilibo.richtext.ui.RichTextScope

--- a/common/src/commonMain/kotlin/dev/msfjarvis/claw/common/comments/Comments.kt
+++ b/common/src/commonMain/kotlin/dev/msfjarvis/claw/common/comments/Comments.kt
@@ -7,7 +7,6 @@ import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.material.CircularProgressIndicator
-import androidx.compose.material.Divider
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -17,6 +16,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import dev.msfjarvis.claw.common.NetworkState
+import dev.msfjarvis.claw.common.ui.Divider
 import dev.msfjarvis.claw.model.LobstersPostDetails
 
 @Composable
@@ -31,7 +31,7 @@ private fun CommentsPageInternal(
 
     items(details.comments) { item -> CommentEntry(item) }
 
-    item { Divider(color = Color.Gray.copy(0.4f)) }
+    item { Divider() }
   }
 }
 

--- a/common/src/commonMain/kotlin/dev/msfjarvis/claw/common/comments/Comments.kt
+++ b/common/src/commonMain/kotlin/dev/msfjarvis/claw/common/comments/Comments.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.produceState
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import dev.msfjarvis.claw.common.NetworkState
 import dev.msfjarvis.claw.common.ui.Divider

--- a/common/src/commonMain/kotlin/dev/msfjarvis/claw/common/posts/LobstersCard.kt
+++ b/common/src/commonMain/kotlin/dev/msfjarvis/claw/common/posts/LobstersCard.kt
@@ -18,7 +18,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredSize
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
-import androidx.compose.material.Divider
 import androidx.compose.material.ripple.rememberRipple
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
@@ -38,6 +37,7 @@ import com.google.accompanist.flowlayout.FlowRow
 import dev.msfjarvis.claw.common.res.commentIcon
 import dev.msfjarvis.claw.common.res.heartBorderIcon
 import dev.msfjarvis.claw.common.res.heartIcon
+import dev.msfjarvis.claw.common.ui.Divider
 import dev.msfjarvis.claw.common.ui.NetworkImage
 import dev.msfjarvis.claw.database.local.SavedPost
 

--- a/common/src/commonMain/kotlin/dev/msfjarvis/claw/common/ui/Divider.kt
+++ b/common/src/commonMain/kotlin/dev/msfjarvis/claw/common/ui/Divider.kt
@@ -1,0 +1,15 @@
+package dev.msfjarvis.claw.common.ui
+
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+@Composable
+fun Divider(modifier: Modifier = Modifier) {
+  androidx.compose.material.Divider(
+    color = MaterialTheme.colorScheme.onBackground.copy(alpha = DividerAlpha),
+    modifier = modifier,
+  )
+}
+
+private const val DividerAlpha = 0.15f


### PR DESCRIPTION
Instead of using Material `Divider` with a specific color (like Gray), this divider sets the color based on the Material You theming. We chose `onBackground` color since the `Scaffold` container color is `background`