### PR TITLE
Align post action icons properly in `LobstersCard`

### DIFF
--- a/common/src/commonMain/kotlin/dev/msfjarvis/claw/common/posts/LobstersCard.kt
+++ b/common/src/commonMain/kotlin/dev/msfjarvis/claw/common/posts/LobstersCard.kt
@@ -52,15 +52,11 @@ fun LobstersCard(
 ) {
   var localSavedState by remember(post, isSaved) { mutableStateOf(isSaved) }
   Box(
-    modifier = modifier
-      .fillMaxWidth()
-      .clickable { postActions.viewPost(post.url, post.commentsUrl) }
-      .padding(
-        start = 16.dp,
-        top = 16.dp,
-        end = 4.dp,
-        bottom = 16.dp
-      ),
+    modifier =
+      modifier
+        .fillMaxWidth()
+        .clickable { postActions.viewPost(post.url, post.commentsUrl) }
+        .padding(start = 16.dp, top = 16.dp, end = 4.dp, bottom = 16.dp),
   ) {
     Row(
       horizontalArrangement = Arrangement.spacedBy(8.dp),
@@ -78,25 +74,25 @@ fun LobstersCard(
         SaveButton(
           isSaved = localSavedState,
           modifier =
-          Modifier.clickable(
-            role = Role.Button,
-            indication = rememberRipple(bounded = false, radius = 24.dp),
-            interactionSource = remember { MutableInteractionSource() },
-          ) {
-            localSavedState = !localSavedState
-            postActions.toggleSave(post)
-          },
+            Modifier.clickable(
+              role = Role.Button,
+              indication = rememberRipple(bounded = false, radius = 24.dp),
+              interactionSource = remember { MutableInteractionSource() },
+            ) {
+              localSavedState = !localSavedState
+              postActions.toggleSave(post)
+            },
         )
         Divider(modifier = Modifier.width(48.dp))
         CommentsButton(
           modifier =
-          Modifier.combinedClickable(
-            role = Role.Button,
-            indication = rememberRipple(bounded = false, radius = 24.dp),
-            interactionSource = remember { MutableInteractionSource() },
-            onClick = { postActions.viewComments(post.shortId) },
-            onLongClick = { postActions.viewCommentsPage(post.commentsUrl) },
-          ),
+            Modifier.combinedClickable(
+              role = Role.Button,
+              indication = rememberRipple(bounded = false, radius = 24.dp),
+              interactionSource = remember { MutableInteractionSource() },
+              onClick = { postActions.viewComments(post.shortId) },
+              onLongClick = { postActions.viewCommentsPage(post.commentsUrl) },
+            ),
         )
       }
     }
@@ -203,9 +199,9 @@ fun TagText(
   Text(
     text = tag,
     modifier =
-    Modifier.background(MaterialTheme.colorScheme.tertiaryContainer, RoundedCornerShape(50))
-      .padding(vertical = 4.dp, horizontal = 12.dp)
-      .then(modifier),
+      Modifier.background(MaterialTheme.colorScheme.tertiaryContainer, RoundedCornerShape(50))
+        .padding(vertical = 4.dp, horizontal = 12.dp)
+        .then(modifier),
     color = MaterialTheme.colorScheme.onTertiaryContainer,
     style = MaterialTheme.typography.labelLarge
   )

--- a/common/src/commonMain/kotlin/dev/msfjarvis/claw/common/posts/LobstersCard.kt
+++ b/common/src/commonMain/kotlin/dev/msfjarvis/claw/common/posts/LobstersCard.kt
@@ -50,9 +50,18 @@ fun LobstersCard(
   modifier: Modifier = Modifier,
 ) {
   var localSavedState by remember(post, isSaved) { mutableStateOf(isSaved) }
-  Box(modifier = modifier.clickable { postActions.viewPost(post.url, post.commentsUrl) }) {
+  Box(
+    modifier = modifier
+      .fillMaxWidth()
+      .clickable { postActions.viewPost(post.url, post.commentsUrl) }
+      .padding(
+        start = 16.dp,
+        top = 16.dp,
+        end = 4.dp,
+        bottom = 16.dp
+      ),
+  ) {
     Row(
-      modifier = Modifier.fillMaxWidth().padding(16.dp),
       horizontalArrangement = Arrangement.spacedBy(8.dp),
       verticalAlignment = Alignment.CenterVertically,
     ) {

--- a/common/src/commonMain/kotlin/dev/msfjarvis/claw/common/posts/LobstersCard.kt
+++ b/common/src/commonMain/kotlin/dev/msfjarvis/claw/common/posts/LobstersCard.kt
@@ -16,6 +16,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.requiredSize
+import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.shape.CircleShape
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.ripple.rememberRipple
@@ -77,25 +78,25 @@ fun LobstersCard(
         SaveButton(
           isSaved = localSavedState,
           modifier =
-            Modifier.clickable(
-              role = Role.Button,
-              indication = rememberRipple(bounded = false, radius = 24.dp),
-              interactionSource = remember { MutableInteractionSource() },
-            ) {
-              localSavedState = !localSavedState
-              postActions.toggleSave(post)
-            },
+          Modifier.clickable(
+            role = Role.Button,
+            indication = rememberRipple(bounded = false, radius = 24.dp),
+            interactionSource = remember { MutableInteractionSource() },
+          ) {
+            localSavedState = !localSavedState
+            postActions.toggleSave(post)
+          },
         )
-        Divider()
+        Divider(modifier = Modifier.width(48.dp))
         CommentsButton(
           modifier =
-            Modifier.combinedClickable(
-              role = Role.Button,
-              indication = rememberRipple(bounded = false, radius = 24.dp),
-              interactionSource = remember { MutableInteractionSource() },
-              onClick = { postActions.viewComments(post.shortId) },
-              onLongClick = { postActions.viewCommentsPage(post.commentsUrl) },
-            ),
+          Modifier.combinedClickable(
+            role = Role.Button,
+            indication = rememberRipple(bounded = false, radius = 24.dp),
+            interactionSource = remember { MutableInteractionSource() },
+            onClick = { postActions.viewComments(post.shortId) },
+            onLongClick = { postActions.viewCommentsPage(post.commentsUrl) },
+          ),
         )
       }
     }
@@ -202,9 +203,9 @@ fun TagText(
   Text(
     text = tag,
     modifier =
-      Modifier.background(MaterialTheme.colorScheme.tertiaryContainer, RoundedCornerShape(50))
-        .padding(vertical = 4.dp, horizontal = 12.dp)
-        .then(modifier),
+    Modifier.background(MaterialTheme.colorScheme.tertiaryContainer, RoundedCornerShape(50))
+      .padding(vertical = 4.dp, horizontal = 12.dp)
+      .then(modifier),
     color = MaterialTheme.colorScheme.onTertiaryContainer,
     style = MaterialTheme.typography.labelLarge
   )

--- a/common/src/commonMain/kotlin/dev/msfjarvis/claw/common/posts/LobstersCard.kt
+++ b/common/src/commonMain/kotlin/dev/msfjarvis/claw/common/posts/LobstersCard.kt
@@ -70,7 +70,7 @@ fun LobstersCard(
         post = post,
       )
       Column(
-        modifier = Modifier.weight(0.15f).fillMaxHeight(),
+        modifier = Modifier.fillMaxHeight(),
         verticalArrangement = Arrangement.spacedBy(8.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
       ) {

--- a/common/src/commonMain/kotlin/dev/msfjarvis/claw/common/posts/LobstersCard.kt
+++ b/common/src/commonMain/kotlin/dev/msfjarvis/claw/common/posts/LobstersCard.kt
@@ -157,12 +157,14 @@ fun SaveButton(
   modifier: Modifier = Modifier,
 ) {
   Crossfade(targetState = isSaved) { saved ->
-    Icon(
-      painter = if (saved) heartIcon else heartBorderIcon,
-      tint = MaterialTheme.colorScheme.secondary,
-      contentDescription = if (saved) "Remove from saved posts" else "Add to saved posts",
-      modifier = modifier.padding(12.dp),
-    )
+    Box(modifier = modifier.padding(12.dp)) {
+      Icon(
+        painter = if (saved) heartIcon else heartBorderIcon,
+        tint = MaterialTheme.colorScheme.secondary,
+        contentDescription = if (saved) "Remove from saved posts" else "Add to saved posts",
+        modifier = Modifier.align(Alignment.Center)
+      )
+    }
   }
 }
 
@@ -170,12 +172,14 @@ fun SaveButton(
 fun CommentsButton(
   modifier: Modifier = Modifier,
 ) {
-  Icon(
-    painter = commentIcon,
-    tint = MaterialTheme.colorScheme.secondary,
-    contentDescription = "Open comments",
-    modifier = modifier.padding(12.dp),
-  )
+  Box(modifier = modifier.padding(12.dp)) {
+    Icon(
+      painter = commentIcon,
+      tint = MaterialTheme.colorScheme.secondary,
+      contentDescription = "Open comments",
+      modifier = Modifier.align(Alignment.Center),
+    )
+  }
 }
 
 @Composable


### PR DESCRIPTION
Basically aligned these icons to be inline with a app bar action item. This adjusts the icons dimens to be similar to how `IconButton` works