### PR TITLE
Introduce API client for Shiori

### DIFF
--- a/api/build.gradle.kts
+++ b/api/build.gradle.kts
@@ -27,7 +27,9 @@ dependencies {
   implementation(libs.jsoup)
 
   testImplementation(testFixtures(libs.eithernet))
+  testImplementation(libs.testcontainers)
   testImplementation(libs.kotlinx.coroutines.test)
   testImplementation(libs.kotlinx.serialization.json)
+  testImplementation(libs.retrofit.kotlinxSerializationConverter)
   addTestDependencies(project)
 }

--- a/api/src/main/kotlin/dev/msfjarvis/claw/api/ShioriApi.kt
+++ b/api/src/main/kotlin/dev/msfjarvis/claw/api/ShioriApi.kt
@@ -1,0 +1,52 @@
+/*
+ * Copyright © 2023 Harsh Shandilya.
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package dev.msfjarvis.claw.api
+
+import android.annotation.SuppressLint
+import dev.msfjarvis.claw.model.shiori.AuthRequest
+import dev.msfjarvis.claw.model.shiori.AuthResponse
+import dev.msfjarvis.claw.model.shiori.Bookmark
+import dev.msfjarvis.claw.model.shiori.BookmarkRequest
+import dev.msfjarvis.claw.model.shiori.BookmarksResponse
+import dev.msfjarvis.claw.model.shiori.EditedBookmark
+import retrofit2.http.Body
+import retrofit2.http.GET
+import retrofit2.http.HTTP
+import retrofit2.http.Header
+import retrofit2.http.POST
+import retrofit2.http.PUT
+
+private const val SESSION_ID_HEADER = "X-Session-Id"
+
+interface ShioriApi {
+  @POST("/api/login") suspend fun login(@Body body: AuthRequest): AuthResponse
+
+  @SuppressLint("RetrofitUsage") // POST without a body is apparently fine?
+  @POST("/api/logout")
+  suspend fun logout(@Header(SESSION_ID_HEADER) sessionId: String)
+
+  @GET("/api/bookmarks")
+  suspend fun getBookmarks(@Header(SESSION_ID_HEADER) sessionId: String): BookmarksResponse
+
+  @POST("/api/bookmarks")
+  suspend fun addBookmark(
+    @Header(SESSION_ID_HEADER) sessionId: String,
+    @Body bookmarkRequest: BookmarkRequest,
+  ): Bookmark
+
+  @PUT("/api/bookmarks")
+  suspend fun editBookmark(
+    @Header(SESSION_ID_HEADER) sessionId: String,
+    @Body bookmark: EditedBookmark,
+  ): Bookmark
+
+  @HTTP(method = "DELETE", path = "/api/bookmarks", hasBody = true)
+  suspend fun deleteBookmark(
+    @Header(SESSION_ID_HEADER) sessionId: String,
+    @Body ids: List<Int>,
+  ): Int
+}

--- a/api/src/test/kotlin/dev/msfjarvis/claw/api/ShioriApiTest.kt
+++ b/api/src/test/kotlin/dev/msfjarvis/claw/api/ShioriApiTest.kt
@@ -1,0 +1,173 @@
+/*
+ * Copyright © 2023 Harsh Shandilya.
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package dev.msfjarvis.claw.api
+
+import com.google.common.truth.Truth.assertThat
+import com.jakewharton.retrofit2.converter.kotlinx.serialization.asConverterFactory
+import dev.msfjarvis.claw.model.shiori.AuthRequest
+import dev.msfjarvis.claw.model.shiori.AuthResponse
+import dev.msfjarvis.claw.model.shiori.Bookmark
+import dev.msfjarvis.claw.model.shiori.BookmarkRequest
+import dev.msfjarvis.claw.model.shiori.EditedBookmark
+import dev.msfjarvis.claw.model.shiori.Tag
+import kotlinx.coroutines.runBlocking
+import kotlinx.coroutines.test.runTest
+import kotlinx.serialization.json.Json
+import okhttp3.MediaType
+import org.junit.jupiter.api.AfterAll
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Disabled
+import org.junit.jupiter.api.Test
+import org.testcontainers.containers.GenericContainer
+import retrofit2.Retrofit
+import retrofit2.create
+
+class ShioriApiTest {
+
+  private lateinit var credentials: AuthResponse
+
+  @BeforeEach
+  fun setUp() {
+    runBlocking { credentials = api.login(AuthRequest(USER, PASSWORD)) }
+  }
+
+  @AfterEach
+  fun tearDown() {
+    runBlocking {
+      val ids = api.getBookmarks(credentials.session).bookmarks.map(Bookmark::id)
+      if (ids.isNotEmpty()) {
+        api.deleteBookmark(credentials.session, ids)
+      }
+      api.logout(credentials.session)
+    }
+  }
+
+  @Test
+  fun getBookmarks() = runTest {
+    val response = api.getBookmarks(credentials.session)
+    assertThat(response.page).isEqualTo(1)
+    assertThat(response.bookmarks).isEmpty()
+  }
+
+  @Test
+  fun addBookmark() = runTest {
+    val response =
+      api.addBookmark(
+        credentials.session,
+        BookmarkRequest(
+          "https://example.com",
+          false,
+          0,
+          emptyList(),
+          "Example Domain",
+          """
+          This domain is for use in illustrative examples in documents.
+          You may use this domain in literature without prior coordination or asking for permission.
+        """
+            .trimIndent(),
+        )
+      )
+    assertThat(response.url).isEqualTo("https://example.com")
+    assertThat(response.title).isEqualTo("Example Domain")
+    assertThat(response.excerpt)
+      .isEqualTo(
+        """
+        This domain is for use in illustrative examples in documents.
+        You may use this domain in literature without prior coordination or asking for permission.
+      """
+          .trimIndent()
+      )
+    assertThat(response.id).isAtLeast(0)
+  }
+
+  @Test
+  @Disabled("Server returns HTTP 500, needs debugging")
+  fun editBookmark() = runTest {
+    val response =
+      api.addBookmark(
+        credentials.session,
+        BookmarkRequest(
+          "https://example.com",
+          false,
+          0,
+          emptyList(),
+          "Example Domain",
+          """
+          This domain is for use in illustrative examples in documents.
+          You may use this domain in literature without prior coordination or asking for permission.
+          """
+            .trimIndent(),
+        )
+      )
+    assertThat(response.tags).isEmpty()
+    val newBookmark =
+      EditedBookmark(
+        id = response.id,
+        tags = listOf(Tag("examples")),
+      )
+    val edited = api.editBookmark(credentials.session, newBookmark)
+    assertThat(edited.tags).isNotEmpty()
+    assertThat(edited.tags).containsExactly(Tag("examples"))
+  }
+
+  @Test
+  fun deleteBookmark() = runTest {
+    val response =
+      api.addBookmark(
+        credentials.session,
+        BookmarkRequest(
+          "https://example.com",
+          false,
+          0,
+          emptyList(),
+          "Example Domain",
+          """
+          This domain is for use in illustrative examples in documents.
+          You may use this domain in literature without prior coordination or asking for permission.
+          """
+            .trimIndent(),
+        )
+      )
+    val count = api.deleteBookmark(credentials.session, listOf(response.id))
+    assertThat(count).isEqualTo(1)
+  }
+
+  companion object {
+    // Default settings for the container
+    private const val USER = "shiori"
+    private const val PASSWORD = "gopher"
+
+    private val container =
+      GenericContainer("ghcr.io/go-shiori/shiori:v1.5.5").withExposedPorts(8080)
+
+    private val json = Json { ignoreUnknownKeys = true }
+
+    // The mapped port can only be obtained after the container has started, so this has to be lazy.
+    private val api by
+      lazy(LazyThreadSafetyMode.NONE) {
+        Retrofit.Builder()
+          .baseUrl("http://${container.host}:${container.firstMappedPort}")
+          .addConverterFactory(json.asConverterFactory(MediaType.get("application/json")))
+          .build()
+          .create<ShioriApi>()
+      }
+
+    @JvmStatic
+    @BeforeAll
+    fun setupContainer() {
+      container.start()
+    }
+
+    @JvmStatic
+    @AfterAll
+    fun destroyContainer() {
+      container.stop()
+    }
+  }
+}

--- a/api/src/test/kotlin/dev/msfjarvis/claw/api/ShioriApiTest.kt
+++ b/api/src/test/kotlin/dev/msfjarvis/claw/api/ShioriApiTest.kt
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.AfterAll
 import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.BeforeEach
-import org.junit.jupiter.api.Disabled
 import org.junit.jupiter.api.Test
 import org.testcontainers.containers.GenericContainer
 import retrofit2.Retrofit
@@ -87,7 +86,6 @@ class ShioriApiTest {
   }
 
   @Test
-  @Disabled("Server returns HTTP 500, needs debugging")
   fun editBookmark() = runTest {
     val response =
       api.addBookmark(
@@ -109,6 +107,8 @@ class ShioriApiTest {
     val newBookmark =
       EditedBookmark(
         id = response.id,
+        url = response.url,
+        title = response.title,
         tags = listOf(Tag("examples")),
       )
     val edited = api.editBookmark(credentials.session, newBookmark)

--- a/build-logic/src/main/kotlin/dev/msfjarvis/claw/gradle/LintConfig.kt
+++ b/build-logic/src/main/kotlin/dev/msfjarvis/claw/gradle/LintConfig.kt
@@ -31,6 +31,8 @@ object LintConfig {
     if (!isJVM) {
       enable += "ComposeM2Api"
       error += "ComposeM2Api"
+      // False-positives in the TestContainers library
+      disable += "DeprecatedCall"
     }
     baseline = project.file("lint-baseline.xml")
     // This is extremely annoying

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -97,6 +97,7 @@ sqldelight-jvmDriver = { module = "app.cash.sqldelight:sqlite-driver", version.r
 sqldelight-primitiveAdapters = { module = "app.cash.sqldelight:primitive-adapters", version.ref = "sqldelight" }
 sqlite-android = "com.github.requery:sqlite-android:3.43.0"
 swipe = "me.saket.swipe:swipe:1.3.0-SNAPSHOT"
+testcontainers = "org.testcontainers:testcontainers:1.19.1"
 truth = "com.google.truth:truth:1.1.5"
 unfurl = "me.saket.unfurl:unfurl:1.7.0"
 

--- a/model/src/main/kotlin/dev/msfjarvis/claw/model/shiori/Account.kt
+++ b/model/src/main/kotlin/dev/msfjarvis/claw/model/shiori/Account.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2021-2023 Harsh Shandilya.
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package dev.msfjarvis.claw.model.shiori
+
+import dev.drewhamilton.poko.Poko
+import kotlinx.serialization.Serializable
+
+@Serializable
+@Poko
+class Account(
+  val id: Int,
+  val username: String,
+  val owner: Boolean,
+)

--- a/model/src/main/kotlin/dev/msfjarvis/claw/model/shiori/AuthRequest.kt
+++ b/model/src/main/kotlin/dev/msfjarvis/claw/model/shiori/AuthRequest.kt
@@ -1,0 +1,19 @@
+/*
+ * Copyright © 2021-2023 Harsh Shandilya.
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package dev.msfjarvis.claw.model.shiori
+
+import dev.drewhamilton.poko.Poko
+import kotlinx.serialization.Serializable
+
+@Serializable
+@Poko
+class AuthRequest(
+  val username: String,
+  val password: String,
+  val remember: Boolean = true,
+  val owner: Boolean = false,
+)

--- a/model/src/main/kotlin/dev/msfjarvis/claw/model/shiori/AuthResponse.kt
+++ b/model/src/main/kotlin/dev/msfjarvis/claw/model/shiori/AuthResponse.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2022-2023 Harsh Shandilya.
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package dev.msfjarvis.claw.model.shiori
+
+import dev.drewhamilton.poko.Poko
+import kotlinx.serialization.Serializable
+
+@Serializable
+@Poko
+class AuthResponse(
+  val session: String,
+  val expires: String,
+  val account: Account,
+)

--- a/model/src/main/kotlin/dev/msfjarvis/claw/model/shiori/Bookmark.kt
+++ b/model/src/main/kotlin/dev/msfjarvis/claw/model/shiori/Bookmark.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2021-2023 Harsh Shandilya.
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package dev.msfjarvis.claw.model.shiori
+
+import dev.drewhamilton.poko.Poko
+import kotlinx.serialization.Serializable
+
+@Serializable
+@Poko
+class Bookmark(
+  val id: Int,
+  val url: String,
+  val title: String,
+  val excerpt: String,
+  val author: String,
+  val public: Int,
+  val modified: String,
+  val imageURL: String,
+  val hasContent: Boolean,
+  val hasArchive: Boolean,
+  val tags: List<Tag>,
+  val createArchive: Boolean,
+)

--- a/model/src/main/kotlin/dev/msfjarvis/claw/model/shiori/BookmarkRequest.kt
+++ b/model/src/main/kotlin/dev/msfjarvis/claw/model/shiori/BookmarkRequest.kt
@@ -1,0 +1,21 @@
+/*
+ * Copyright © 2021-2023 Harsh Shandilya.
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package dev.msfjarvis.claw.model.shiori
+
+import dev.drewhamilton.poko.Poko
+import kotlinx.serialization.Serializable
+
+@Serializable
+@Poko
+class BookmarkRequest(
+  val url: String,
+  val createArchive: Boolean,
+  val public: Int,
+  val tags: List<Tag>,
+  val title: String,
+  val excerpt: String,
+)

--- a/model/src/main/kotlin/dev/msfjarvis/claw/model/shiori/BookmarksResponse.kt
+++ b/model/src/main/kotlin/dev/msfjarvis/claw/model/shiori/BookmarksResponse.kt
@@ -1,0 +1,18 @@
+/*
+ * Copyright © 2022-2023 Harsh Shandilya.
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package dev.msfjarvis.claw.model.shiori
+
+import dev.drewhamilton.poko.Poko
+import kotlinx.serialization.Serializable
+
+@Serializable
+@Poko
+class BookmarksResponse(
+  val bookmarks: List<Bookmark>,
+  val maxPage: Int,
+  val page: Int,
+)

--- a/model/src/main/kotlin/dev/msfjarvis/claw/model/shiori/EditedBookmark.kt
+++ b/model/src/main/kotlin/dev/msfjarvis/claw/model/shiori/EditedBookmark.kt
@@ -13,8 +13,8 @@ import kotlinx.serialization.Serializable
 @Poko
 class EditedBookmark(
   val id: Int,
-  val url: String? = null,
-  val title: String? = null,
+  val url: String,
+  val title: String,
   val excerpt: String? = null,
   val author: String? = null,
   val public: Int? = null,

--- a/model/src/main/kotlin/dev/msfjarvis/claw/model/shiori/EditedBookmark.kt
+++ b/model/src/main/kotlin/dev/msfjarvis/claw/model/shiori/EditedBookmark.kt
@@ -1,0 +1,27 @@
+/*
+ * Copyright © 2023 Harsh Shandilya.
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package dev.msfjarvis.claw.model.shiori
+
+import dev.drewhamilton.poko.Poko
+import kotlinx.serialization.Serializable
+
+@Serializable
+@Poko
+class EditedBookmark(
+  val id: Int,
+  val url: String? = null,
+  val title: String? = null,
+  val excerpt: String? = null,
+  val author: String? = null,
+  val public: Int? = null,
+  val modified: String? = null,
+  val imageURL: String? = null,
+  val hasContent: Boolean? = null,
+  val hasArchive: Boolean? = null,
+  val tags: List<Tag>? = null,
+  val createArchive: Boolean? = null,
+)

--- a/model/src/main/kotlin/dev/msfjarvis/claw/model/shiori/Tag.kt
+++ b/model/src/main/kotlin/dev/msfjarvis/claw/model/shiori/Tag.kt
@@ -1,0 +1,12 @@
+/*
+ * Copyright © 2022-2023 Harsh Shandilya.
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package dev.msfjarvis.claw.model.shiori
+
+import dev.drewhamilton.poko.Poko
+import kotlinx.serialization.Serializable
+
+@Serializable @Poko class Tag(val name: String)


### PR DESCRIPTION
Adds a Retrofit API for the [Shiori bookmarks manager](https://github.com/go-shiori/shiori/) with the intent to one day use this as a remote sync target for saved posts.