### PR TITLE
Remember the comment expanded/collapsed state when scrolling.

### DIFF
--- a/common/src/main/kotlin/dev/msfjarvis/claw/common/comments/CommentNode.kt
+++ b/common/src/main/kotlin/dev/msfjarvis/claw/common/comments/CommentNode.kt
@@ -6,15 +6,15 @@
  */
 package dev.msfjarvis.claw.common.comments
 
-import dev.msfjarvis.claw.database.local.PostComments
 import dev.msfjarvis.claw.model.Comment
 
-internal class CommentNode(
+internal data class CommentNode(
   val comment: Comment,
   private var parent: CommentNode? = null,
   val children: MutableList<CommentNode> = mutableListOf(),
   val isUnread: Boolean = false,
   val indentLevel: Int,
+  val isExpanded: Boolean = true,
 ) {
 
   fun addChild(child: CommentNode) {
@@ -50,6 +50,7 @@ internal class CommentNode(
     if (children != other.children) return false
     if (isUnread != other.isUnread) return false
     if (indentLevel != other.indentLevel) return false
+    if (isExpanded != other.isExpanded) return false
 
     return true
   }
@@ -59,37 +60,7 @@ internal class CommentNode(
     result = 31 * result + children.hashCode()
     result = 31 * result + isUnread.hashCode()
     result = 31 * result + indentLevel
+    result = 31 * result + isExpanded.hashCode()
     return result
   }
-}
-
-internal fun createListNode(
-  comments: List<Comment>,
-  commentState: PostComments?,
-): MutableList<CommentNode> {
-  val commentNodes = mutableListOf<CommentNode>()
-  val isUnread = { id: String -> commentState?.commentIds?.contains(id) == false }
-
-  for (i in comments.indices) {
-    if (comments[i].parentComment == null) {
-      commentNodes.add(
-        CommentNode(
-          comment = comments[i],
-          isUnread = isUnread(comments[i].shortId),
-          indentLevel = 1,
-        )
-      )
-    } else {
-      commentNodes.lastOrNull()?.let { commentNode ->
-        commentNode.addChild(
-          CommentNode(
-            comment = comments[i],
-            isUnread = isUnread(comments[i].shortId),
-            indentLevel = commentNode.indentLevel + 1,
-          )
-        )
-      }
-    }
-  }
-  return commentNodes
 }

--- a/common/src/main/kotlin/dev/msfjarvis/claw/common/comments/CommentsHandler.kt
+++ b/common/src/main/kotlin/dev/msfjarvis/claw/common/comments/CommentsHandler.kt
@@ -1,0 +1,60 @@
+/*
+ * Copyright © 2024 Harsh Shandilya.
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package dev.msfjarvis.claw.common.comments
+
+import dev.msfjarvis.claw.database.local.PostComments
+import dev.msfjarvis.claw.model.Comment
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+internal class CommentsHandler {
+
+  private val _listItems: MutableStateFlow<List<CommentNode>> = MutableStateFlow(emptyList())
+  val listItems: StateFlow<List<CommentNode>> = _listItems.asStateFlow()
+
+  fun createListNode(comments: List<Comment>, commentState: PostComments?) {
+    val commentNodes = mutableListOf<CommentNode>()
+    val isUnread = { id: String -> commentState?.commentIds?.contains(id) == false }
+
+    for (i in comments.indices) {
+      if (comments[i].parentComment == null) {
+        commentNodes.add(
+          CommentNode(
+            comment = comments[i],
+            isUnread = isUnread(comments[i].shortId),
+            indentLevel = 1,
+          )
+        )
+      } else {
+        commentNodes.lastOrNull()?.let { commentNode ->
+          commentNode.addChild(
+            CommentNode(
+              comment = comments[i],
+              isUnread = isUnread(comments[i].shortId),
+              indentLevel = commentNode.indentLevel + 1,
+            )
+          )
+        }
+      }
+    }
+
+    _listItems.value = commentNodes
+  }
+
+  fun updateListNode(shortId: String, isExpanded: Boolean) {
+    val listNode = _listItems.value.toMutableList()
+    val index = listNode.indexOfFirst { it.comment.shortId == shortId }
+
+    if (index != -1) {
+      val commentNode = listNode[index].copy(isExpanded = isExpanded)
+      listNode[index] = commentNode
+
+      _listItems.value = listNode.toList()
+    }
+  }
+}

--- a/common/src/main/kotlin/dev/msfjarvis/claw/common/comments/CommentsPage.kt
+++ b/common/src/main/kotlin/dev/msfjarvis/claw/common/comments/CommentsPage.kt
@@ -60,6 +60,7 @@ fun CommentsPage(
         markSeenComments = markSeenComments,
         openUserProfile = openUserProfile,
         contentPadding = contentPadding,
+        commentsHandler = CommentsHandler(),
         modifier = modifier.fillMaxSize(),
       )
     }


### PR DESCRIPTION
Remember the comment expanded/collapsed state when scrolling. Previously,
the state was remembered inside the `Node` composable. When the users scroll,
and `Node` re-composes, the state was being reset.

In this commit, we add the collapsed state into the `CommentNode`. This makes
sure that the state is retained even when the UI is re-composed.

Fixes #651 