### PR TITLE
add a key parameter to prevent crash issue #845

### DIFF
--- a/android/src/main/kotlin/dev/msfjarvis/claw/android/ui/screens/LobstersPostsScreen.kt
+++ b/android/src/main/kotlin/dev/msfjarvis/claw/android/ui/screens/LobstersPostsScreen.kt
@@ -85,7 +85,7 @@ fun LobstersPostsScreen(
 ) {
   val libraries by produceLibraries()
   val clawBackStack = ClawBackStack(Hottest)
-  val listDetailStrategy = rememberListDetailSceneStrategy<NavKey>()
+  val listDetailStrategy = rememberListDetailSceneStrategy<NavKey>(key = windowSizeClass)
 
   // region Pain
   val context = LocalContext.current


### PR DESCRIPTION
Fix configuration change crash in comments page

Fixes #845

**Problem**
Comments page crashes on configuration changes (rotation, theme, language) due to Nav3 regression where `rememberListDetailSceneStrategy` loses state.

**Root cause**
`rememberListDetailSceneStrategy<NavKey>()` was called without keys, causing it to be recreated on configuration changes and losing navigation state.

**Solution**
Key the strategy to `windowSizeClass` to preserve state across configuration changes:

