### PR TITLE
Fix configuration change crash in comments page

### DIFF
--- a/android/src/main/kotlin/dev/msfjarvis/claw/android/ui/screens/LobstersPostsScreen.kt
+++ b/android/src/main/kotlin/dev/msfjarvis/claw/android/ui/screens/LobstersPostsScreen.kt
@@ -84,8 +84,8 @@ fun LobstersPostsScreen(
   viewModel: ClawViewModel = injectedViewModel(),
 ) {
   val libraries by produceLibraries()
-  val clawBackStack = ClawBackStack(Hottest)
-  val listDetailStrategy = rememberListDetailSceneStrategy<NavKey>(key = windowSizeClass)
+  val clawBackStack = remember { ClawBackStack(Hottest) }
+  val listDetailStrategy = rememberListDetailSceneStrategy<NavKey>()
 
   // region Pain
   val context = LocalContext.current


### PR DESCRIPTION
Fix configuration change crash in comments page

Fixes #845

**Problem**
Comments page crashes on configuration changes (rotation, theme, language) due to navigation state being lost when `ClawBackStack` gets recreated.

**Root cause**
`ClawBackStack` was being instantiated directly without `remember`, causing it to be recreated on every configuration change and losing the navigation stack state.

**Solution**
Wrap `ClawBackStack` in `remember` to preserve navigation state across configuration changes:
