### PR TITLE
Implement support for synchronizing tags with lobsters

### DIFF
--- a/android/build.gradle.kts
+++ b/android/build.gradle.kts
@@ -5,12 +5,15 @@
  * https://opensource.org/licenses/MIT.
  */
 @file:Suppress("UnstableApiUsage")
+@file:OptIn(ExperimentalTime::class)
 
 import dev.msfjarvis.claw.gradle.addTestDependencies
 import dev.zacsweers.metro.gradle.DiagnosticSeverity
 import groovy.json.JsonOutput
 import groovy.json.JsonSlurper
 import java.io.File
+import kotlin.time.Clock
+import kotlin.time.ExperimentalTime
 
 plugins {
   id("dev.msfjarvis.claw.android-application")
@@ -78,7 +81,7 @@ val prepareEmbeddedZiplineParser =
 
       val unsigned =
         ((parsed["unsigned"] as? Map<*, *>)?.toMutableMap() ?: mutableMapOf()).apply {
-          put("freshAtEpochMs", System.currentTimeMillis())
+          put("freshAtEpochMs", Clock.System.now().toEpochMilliseconds())
         }
       parsed["unsigned"] = unsigned
 

--- a/android/src/main/kotlin/dev/msfjarvis/claw/android/ui/screens/LobstersPostsScreen.kt
+++ b/android/src/main/kotlin/dev/msfjarvis/claw/android/ui/screens/LobstersPostsScreen.kt
@@ -469,7 +469,12 @@ fun LobstersPostsScreen(
                 modifier = Modifier.fillMaxSize(),
               )
             }
-            entry<TagFiltering> { TagList(contentPadding = contentPadding) }
+            entry<TagFiltering> {
+              TagList(
+                popBackStack = { popBackStack(backStack) },
+                contentPadding = contentPadding,
+              )
+            }
           },
       )
     }

--- a/android/src/main/kotlin/dev/msfjarvis/claw/android/zipline/AndroidZiplineParserClient.kt
+++ b/android/src/main/kotlin/dev/msfjarvis/claw/android/zipline/AndroidZiplineParserClient.kt
@@ -162,6 +162,10 @@ class AndroidZiplineParserClient(
 
     override fun parseReplyForm(html: String) = onZiplineThread { delegate.parseReplyForm(html) }
 
+    override fun parseFiltersPage(html: String) = onZiplineThread {
+      delegate.parseFiltersPage(html)
+    }
+
     override fun close() = onZiplineThread { delegate.close() }
   }
 

--- a/api/src/main/kotlin/dev/msfjarvis/claw/api/AuthenticatedLobstersApi.kt
+++ b/api/src/main/kotlin/dev/msfjarvis/claw/api/AuthenticatedLobstersApi.kt
@@ -9,6 +9,7 @@ package dev.msfjarvis.claw.api
 import com.slack.eithernet.ApiResult
 import com.slack.eithernet.ApiResult.Failure
 import com.slack.eithernet.ApiResult.Success
+import dev.msfjarvis.claw.model.FiltersPage
 import dev.msfjarvis.claw.model.ReplyForm
 import dev.zacsweers.metro.Inject
 import java.io.IOException
@@ -60,6 +61,30 @@ class AuthenticatedLobstersApi(private val api: LobstersApi) {
         }
         is Failure -> formResponse.toUnitFailure()
       }
+    }
+  }
+
+  suspend fun getFiltersPage(): ApiResult<FiltersPage, Unit> = api.getFilters()
+
+  suspend fun saveBlockedTags(tags: Set<String>): ApiResult<Set<String>, Unit> {
+    return when (val page = getFiltersPage()) {
+      is Success -> {
+        val authenticityToken = page.value.authenticityToken
+        if (authenticityToken.isBlank()) {
+          ApiResult.unknownFailure(IOException("Lobsters filters page token was empty"))
+        } else {
+          val fields = tags.sorted().associate { tag -> "tags[$tag]" to "1" }
+          when (val save = api.saveFilters(authenticityToken, fields)) {
+            is Success ->
+              when (val refreshed = getFiltersPage()) {
+                is Success -> ApiResult.success(refreshed.value.blockedTags)
+                is Failure -> refreshed.toUnitFailure()
+              }
+            is Failure -> save.toUnitFailure()
+          }
+        }
+      }
+      is Failure -> page.toUnitFailure()
     }
   }
 

--- a/api/src/main/kotlin/dev/msfjarvis/claw/api/LobstersApi.kt
+++ b/api/src/main/kotlin/dev/msfjarvis/claw/api/LobstersApi.kt
@@ -8,12 +8,16 @@ package dev.msfjarvis.claw.api
 
 import com.slack.eithernet.ApiResult
 import dev.msfjarvis.claw.model.CSRFToken
+import dev.msfjarvis.claw.model.FiltersPage
 import dev.msfjarvis.claw.model.LobstersPost
 import dev.msfjarvis.claw.model.LobstersPostDetails
 import dev.msfjarvis.claw.model.ReplyForm
 import dev.msfjarvis.claw.model.Tag
 import dev.msfjarvis.claw.model.User
 import okhttp3.MultipartBody
+import retrofit2.http.Field
+import retrofit2.http.FieldMap
+import retrofit2.http.FormUrlEncoded
 import retrofit2.http.GET
 import retrofit2.http.Header
 import retrofit2.http.Multipart
@@ -38,6 +42,16 @@ interface LobstersApi {
   @GET("/") suspend fun getCSRFToken(): ApiResult<CSRFToken, Unit>
 
   @GET("tags") suspend fun getTags(): ApiResult<List<Tag>, Unit>
+
+  @GET("filters") suspend fun getFilters(): ApiResult<FiltersPage, Unit>
+
+  @FormUrlEncoded
+  @POST("filters")
+  suspend fun saveFilters(
+    @Field("authenticity_token") authenticityToken: String,
+    @FieldMap(encoded = true) tags: Map<String, String>,
+    @Field("commit") commit: String = "Save Filters",
+  ): ApiResult<Unit, Unit>
 
   @Multipart
   @POST("comments/{commentId}/upvote")

--- a/api/src/main/kotlin/dev/msfjarvis/claw/api/converters/ParserModelMappings.kt
+++ b/api/src/main/kotlin/dev/msfjarvis/claw/api/converters/ParserModelMappings.kt
@@ -8,6 +8,7 @@ package dev.msfjarvis.claw.api.converters
 
 import dev.msfjarvis.claw.model.CSRFToken
 import dev.msfjarvis.claw.model.Comment
+import dev.msfjarvis.claw.model.FiltersPage
 import dev.msfjarvis.claw.model.LobstersPost
 import dev.msfjarvis.claw.model.LobstersPostDetails
 import dev.msfjarvis.claw.model.ReplyForm
@@ -76,6 +77,13 @@ internal fun dev.msfjarvis.claw.parser.model.Tag.toModel(): Tag =
     category = category,
     isMedia = isMedia,
     hotnessMod = hotnessMod,
+  )
+
+internal fun dev.msfjarvis.claw.parser.model.FiltersPage.toModel(): FiltersPage =
+  FiltersPage(
+    authenticityToken = authenticityToken,
+    tags = tags.map { it.toModel() },
+    blockedTags = blockedTags,
   )
 
 internal fun dev.msfjarvis.claw.parser.model.User.toModel(): User =

--- a/api/src/main/kotlin/dev/msfjarvis/claw/api/converters/ZiplineHtmlConverterFactory.kt
+++ b/api/src/main/kotlin/dev/msfjarvis/claw/api/converters/ZiplineHtmlConverterFactory.kt
@@ -8,6 +8,7 @@ package dev.msfjarvis.claw.api.converters
 
 import dev.msfjarvis.claw.api.LobstersParserClient
 import dev.msfjarvis.claw.model.CSRFToken
+import dev.msfjarvis.claw.model.FiltersPage
 import dev.msfjarvis.claw.model.LobstersPost
 import dev.msfjarvis.claw.model.LobstersPostDetails
 import dev.msfjarvis.claw.model.ReplyForm
@@ -50,6 +51,8 @@ class ZiplineHtmlConverterFactory(private val parserClient: LobstersParserClient
         HtmlConverter { html -> parserClient.service().parsePostDetails(html).toModel() }
       normalizedType == ReplyForm::class.java ->
         HtmlConverter { html -> parserClient.service().parseReplyForm(html).toModel() }
+      normalizedType == FiltersPage::class.java ->
+        HtmlConverter { html -> parserClient.service().parseFiltersPage(html).toModel() }
       normalizedType == User::class.java ->
         HtmlConverter { html -> parserClient.service().parseUser(html).toModel() }
       else -> null

--- a/api/src/test/kotlin/dev/msfjarvis/claw/api/AuthenticatedLobstersApiHeaderTest.kt
+++ b/api/src/test/kotlin/dev/msfjarvis/claw/api/AuthenticatedLobstersApiHeaderTest.kt
@@ -9,6 +9,7 @@ package dev.msfjarvis.claw.api
 import com.google.common.truth.Truth.assertThat
 import com.slack.eithernet.ApiResult
 import dev.msfjarvis.claw.model.CSRFToken
+import dev.msfjarvis.claw.model.FiltersPage
 import dev.msfjarvis.claw.model.LobstersPost
 import dev.msfjarvis.claw.model.LobstersPostDetails
 import dev.msfjarvis.claw.model.ReplyForm
@@ -59,6 +60,14 @@ private class RecordingLobstersApi : LobstersApi {
     ApiResult.success(CSRFToken("csrf-token"))
 
   override suspend fun getTags(): ApiResult<List<Tag>, Unit> = error("unused")
+
+  override suspend fun getFilters(): ApiResult<FiltersPage, Unit> = error("unused")
+
+  override suspend fun saveFilters(
+    authenticityToken: String,
+    tags: Map<String, String>,
+    commit: String,
+  ): ApiResult<Unit, Unit> = error("unused")
 
   override suspend fun upvoteComment(
     commentId: String,

--- a/api/src/test/kotlin/dev/msfjarvis/claw/api/AuthenticatedLobstersApiTest.kt
+++ b/api/src/test/kotlin/dev/msfjarvis/claw/api/AuthenticatedLobstersApiTest.kt
@@ -6,9 +6,20 @@
  */
 package dev.msfjarvis.claw.api
 
+import com.google.common.truth.Truth.assertThat
+import com.slack.eithernet.ApiResult
+import com.slack.eithernet.ApiResult.Failure
 import com.slack.eithernet.ApiResult.Success
+import dev.msfjarvis.claw.model.CSRFToken
+import dev.msfjarvis.claw.model.FiltersPage
+import dev.msfjarvis.claw.model.LobstersPost
+import dev.msfjarvis.claw.model.LobstersPostDetails
+import dev.msfjarvis.claw.model.ReplyForm
+import dev.msfjarvis.claw.model.Tag
+import dev.msfjarvis.claw.model.User
 import dev.msfjarvis.claw.util.TestUtils.assertIs
 import kotlinx.coroutines.test.runTest
+import okhttp3.MultipartBody
 import org.junit.jupiter.api.Test
 
 class AuthenticatedLobstersApiTest {
@@ -35,4 +46,171 @@ class AuthenticatedLobstersApiTest {
 
     assertIs<Success<Unit>>(result)
   }
+
+  @Test
+  fun `save blocked tags posts full permanent set and returns canonical refreshed set`() = runTest {
+    val api =
+      RecordingFiltersLobstersApi(
+        filtersResponses =
+          ArrayDeque(
+            listOf(
+              FiltersPage(
+                authenticityToken = "filters-token",
+                tags = emptyList(),
+                blockedTags = setOf("existing"),
+              ),
+              FiltersPage(
+                authenticityToken = "filters-token",
+                tags = emptyList(),
+                blockedTags = setOf("android", "kotlin"),
+              ),
+            )
+          )
+      )
+    val authenticatedApi = AuthenticatedLobstersApi(api)
+
+    val result = authenticatedApi.saveBlockedTags(setOf("kotlin", "android"))
+
+    assertThat(api.savedAuthenticityToken).isEqualTo("filters-token")
+    assertThat(api.savedTags).containsExactly("tags[android]", "1", "tags[kotlin]", "1")
+    assertThat(api.savedCommit).isEqualTo("Save Filters")
+    assertIs<Success<Set<String>>>(result)
+    assertThat(result.value).containsExactly("android", "kotlin")
+  }
+
+  @Test
+  fun `save blocked tags fails fast when filters token is blank`() = runTest {
+    val api =
+      RecordingFiltersLobstersApi(
+        filtersResponses =
+          ArrayDeque(
+            listOf(
+              FiltersPage(authenticityToken = "", tags = emptyList(), blockedTags = emptySet())
+            )
+          )
+      )
+    val authenticatedApi = AuthenticatedLobstersApi(api)
+
+    val result = authenticatedApi.saveBlockedTags(setOf("kotlin"))
+
+    assertIs<Failure.UnknownFailure>(result)
+    assertThat(result.error).hasMessageThat().isEqualTo("Lobsters filters page token was empty")
+    assertThat(api.saveFiltersCallCount).isEqualTo(0)
+  }
+
+  @Test
+  fun `save blocked tags re-reads filters after save`() = runTest {
+    val api =
+      RecordingFiltersLobstersApi(
+        filtersResponses =
+          ArrayDeque(
+            listOf(
+              FiltersPage(
+                authenticityToken = "filters-token",
+                tags = emptyList(),
+                blockedTags = setOf("old"),
+              ),
+              FiltersPage(
+                authenticityToken = "filters-token",
+                tags = emptyList(),
+                blockedTags = setOf("canonical"),
+              ),
+            )
+          )
+      )
+    val authenticatedApi = AuthenticatedLobstersApi(api)
+
+    val result = authenticatedApi.saveBlockedTags(setOf("draft"))
+
+    assertThat(api.getFiltersCallCount).isEqualTo(2)
+    assertIs<Success<Set<String>>>(result)
+    assertThat(result.value).containsExactly("canonical")
+  }
+}
+
+private class RecordingFiltersLobstersApi(
+  private val filtersResponses: ArrayDeque<FiltersPage>,
+  private val saveFiltersResult: ApiResult<Unit, Unit> = ApiResult.success(Unit),
+) : LobstersApi {
+  var getFiltersCallCount: Int = 0
+    private set
+
+  var saveFiltersCallCount: Int = 0
+    private set
+
+  var savedAuthenticityToken: String? = null
+    private set
+
+  var savedTags: Map<String, String>? = null
+    private set
+
+  var savedCommit: String? = null
+    private set
+
+  override suspend fun getHottestPosts(page: Int): ApiResult<List<LobstersPost>, Unit> =
+    error("unused")
+
+  override suspend fun getNewestPosts(page: Int): ApiResult<List<LobstersPost>, Unit> =
+    error("unused")
+
+  override suspend fun getPostDetails(postId: String): ApiResult<LobstersPostDetails, Unit> =
+    error("unused")
+
+  override suspend fun getUser(username: String): ApiResult<User, Unit> = error("unused")
+
+  override suspend fun getCSRFToken(): ApiResult<CSRFToken, Unit> = error("unused")
+
+  override suspend fun getTags(): ApiResult<List<Tag>, Unit> = error("unused")
+
+  override suspend fun getFilters(): ApiResult<FiltersPage, Unit> {
+    getFiltersCallCount += 1
+    return ApiResult.success(filtersResponses.removeFirst())
+  }
+
+  override suspend fun saveFilters(
+    authenticityToken: String,
+    tags: Map<String, String>,
+    commit: String,
+  ): ApiResult<Unit, Unit> {
+    saveFiltersCallCount += 1
+    savedAuthenticityToken = authenticityToken
+    savedTags = tags
+    savedCommit = commit
+    return saveFiltersResult
+  }
+
+  override suspend fun upvoteComment(
+    commentId: String,
+    csrfToken: String,
+    requestedWith: String,
+    reason: MultipartBody.Part,
+  ): ApiResult<Unit, Unit> = error("unused")
+
+  override suspend fun unvoteComment(
+    commentId: String,
+    csrfToken: String,
+    requestedWith: String,
+    reason: MultipartBody.Part,
+  ): ApiResult<Unit, Unit> = error("unused")
+
+  override suspend fun getReplyForm(
+    commentId: String,
+    csrfToken: String,
+    requestedWith: String,
+    referer: String,
+  ): ApiResult<ReplyForm, Unit> = error("unused")
+
+  override suspend fun postReply(
+    csrfToken: String,
+    requestedWith: String,
+    referer: String,
+    origin: String,
+    accept: String,
+    authenticityToken: MultipartBody.Part,
+    storyId: MultipartBody.Part,
+    method: MultipartBody.Part,
+    parentCommentShortId: MultipartBody.Part,
+    comment: MultipartBody.Part,
+    commit: MultipartBody.Part,
+  ): ApiResult<Unit, Unit> = error("unused")
 }

--- a/api/src/test/resources/filters_page_logged_in.html
+++ b/api/src/test/resources/filters_page_logged_in.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html>
+  <body>
+    <form action="/filters" method="post">
+      <input type="hidden" name="authenticity_token" value="filters-token" />
+      <table>
+        <tr data-category="language" data-hotness-mod="1.2">
+          <td>
+            <label>
+              <input type="checkbox" name="tags[kotlin]" checked="checked" />
+              <a class="tag" href="/t/kotlin">kotlin</a>
+              <span>Kotlin discussions</span>
+            </label>
+          </td>
+        </tr>
+        <tr data-category="topic" data-privileged="true" data-hotness-mod="0.3">
+          <td>
+            <label>
+              <input type="checkbox" name="tags[inactive]" />
+              <a class="tag tag_is_media" href="/t/inactive">inactive</a>
+              <span class="inactive_tag">Inactive tag description</span>
+            </label>
+          </td>
+        </tr>
+      </table>
+    </form>
+  </body>
+</html>

--- a/common/build.gradle.kts
+++ b/common/build.gradle.kts
@@ -41,6 +41,7 @@ dependencies {
   api(projects.model)
 
   implementation(platform(libs.okhttp.bom))
+  implementation(libs.androidx.activity.compose)
   implementation(libs.androidx.annotation)
   implementation(libs.androidx.browser)
   implementation(libs.androidx.compose.animation)

--- a/common/src/main/kotlin/dev/msfjarvis/claw/common/comments/CommentEntry.kt
+++ b/common/src/main/kotlin/dev/msfjarvis/claw/common/comments/CommentEntry.kt
@@ -381,7 +381,7 @@ internal fun previewCommentNode(isUpvoted: Boolean = false) =
   )
 
 private fun buildCommentAgeString(timestamp: Instant, edited: Boolean): String {
-  val now = System.currentTimeMillis()
+  val now = Clock.System.now().toEpochMilliseconds()
   val relativeTime =
     DateUtils.getRelativeTimeSpanString(
       timestamp.toEpochMilliseconds(),

--- a/common/src/main/kotlin/dev/msfjarvis/claw/common/comments/CommentsHandler.kt
+++ b/common/src/main/kotlin/dev/msfjarvis/claw/common/comments/CommentsHandler.kt
@@ -9,13 +9,13 @@ package dev.msfjarvis.claw.common.comments
 import dev.msfjarvis.claw.model.Comment
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.asStateFlow
 
 internal class CommentsHandler {
 
   private var rootNodes = emptyList<CommentNode>()
-  private val _visibleNodes: MutableStateFlow<List<CommentNode>> = MutableStateFlow(emptyList())
-  val listItems: StateFlow<List<CommentNode>> = _visibleNodes.asStateFlow()
+  val listItems: StateFlow<List<CommentNode>>
+    field = MutableStateFlow(emptyList())
+
   private var collapsedCommentIds = setOf<String>()
 
   private fun updateVisibleNodes() {
@@ -27,7 +27,7 @@ internal class CommentsHandler {
       }
     }
     rootNodes.forEach { traverse(it) }
-    _visibleNodes.value = flatList
+    listItems.value = flatList
   }
 
   private fun isUnread(commentId: String, seenCommentsState: SeenCommentsState) =

--- a/common/src/main/kotlin/dev/msfjarvis/claw/common/tags/TagBlockRepository.kt
+++ b/common/src/main/kotlin/dev/msfjarvis/claw/common/tags/TagBlockRepository.kt
@@ -13,6 +13,7 @@ import dev.msfjarvis.claw.core.coroutines.DatabaseWriteDispatcher
 import dev.msfjarvis.claw.database.local.TagBlocksQueries
 import dev.msfjarvis.claw.model.TagBlock
 import dev.zacsweers.metro.Inject
+import kotlin.time.Clock
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.map
@@ -25,7 +26,7 @@ class TagBlockRepository(
   @param:DatabaseWriteDispatcher private val writeDispatcher: CoroutineDispatcher,
 ) {
   fun getSavedTags(): Flow<Set<String>> {
-    val now = System.currentTimeMillis()
+    val now = Clock.System.now().toEpochMilliseconds()
     return tagBlocksQueries.selectActiveTags(now).asFlow().mapToList(readDispatcher).map {
       it.toSet()
     }
@@ -57,7 +58,7 @@ class TagBlockRepository(
   }
 
   suspend fun removeExpiredTags() {
-    val now = System.currentTimeMillis()
+    val now = Clock.System.now().toEpochMilliseconds()
     withContext(writeDispatcher) { tagBlocksQueries.deleteExpired(now) }
   }
 }

--- a/common/src/main/kotlin/dev/msfjarvis/claw/common/tags/TagBlockRepository.kt
+++ b/common/src/main/kotlin/dev/msfjarvis/claw/common/tags/TagBlockRepository.kt
@@ -41,6 +41,17 @@ class TagBlockRepository(
     withContext(writeDispatcher) { tagBlocksQueries.insertOrReplace(tag, expirationMillis) }
   }
 
+  suspend fun replaceTagBlocks(blocks: List<TagBlock>) {
+    withContext(writeDispatcher) {
+      tagBlocksQueries.transaction {
+        tagBlocksQueries.deleteAll()
+        blocks.forEach { block ->
+          tagBlocksQueries.insertOrReplace(block.tag, block.expirationMillis)
+        }
+      }
+    }
+  }
+
   suspend fun removeTagBlock(tag: String) {
     withContext(writeDispatcher) { tagBlocksQueries.deleteByTag(tag) }
   }

--- a/common/src/main/kotlin/dev/msfjarvis/claw/common/tags/TagFilterViewModel.kt
+++ b/common/src/main/kotlin/dev/msfjarvis/claw/common/tags/TagFilterViewModel.kt
@@ -15,21 +15,30 @@ import com.github.michaelbull.result.coroutines.runSuspendCatching
 import com.github.michaelbull.result.fold
 import com.slack.eithernet.ApiResult.Failure
 import com.slack.eithernet.ApiResult.Success
+import dev.msfjarvis.claw.api.AuthenticatedLobstersApi
 import dev.msfjarvis.claw.api.LobstersApi
 import dev.msfjarvis.claw.api.toError
 import dev.msfjarvis.claw.common.NetworkState
 import dev.msfjarvis.claw.core.coroutines.IODispatcher
+import dev.msfjarvis.claw.core.network.SessionCookieStore
 import dev.msfjarvis.claw.model.Tag
+import dev.msfjarvis.claw.model.TagBlock
 import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesIntoMap
 import dev.zacsweers.metro.Inject
 import dev.zacsweers.metrox.viewmodel.ViewModelKey
 import java.io.IOException
 import kotlinx.collections.immutable.ImmutableList
+import kotlinx.collections.immutable.ImmutableSet
 import kotlinx.collections.immutable.toImmutableList
 import kotlinx.collections.immutable.toPersistentSet
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
 
@@ -38,46 +47,150 @@ import kotlinx.coroutines.withContext
 @ContributesIntoMap(AppScope::class)
 class TagFilterViewModel(
   private val api: LobstersApi,
+  private val authenticatedApi: AuthenticatedLobstersApi,
   private val tagBlockRepository: TagBlockRepository,
+  private val sessionCookieStore: SessionCookieStore,
   @param:IODispatcher private val ioDispatcher: CoroutineDispatcher,
 ) : ViewModel() {
 
-  val filteredTags = tagBlockRepository.getSavedTags().map(Set<String>::toPersistentSet)
-  val tagBlocks = tagBlockRepository.getTagBlocks()
+  val tagBlocks: StateFlow<List<TagBlock>>
+    field = MutableStateFlow<List<TagBlock>>(emptyList())
+
+  val filteredTags: StateFlow<ImmutableSet<String>> =
+    tagBlocks
+      .map { blocks -> blocks.mapTo(mutableSetOf()) { it.tag }.toPersistentSet() }
+      .stateIn(viewModelScope, SharingStarted.Eagerly, emptySet<String>().toPersistentSet())
 
   var allTags by mutableStateOf<NetworkState>(NetworkState.Loading)
     private set
 
+  var isDirty by mutableStateOf(false)
+    private set
+
+  var isSaving by mutableStateOf(false)
+    private set
+
+  var saveError by mutableStateOf<String?>(null)
+    private set
+
+  private var initialBlocks: List<TagBlock> = emptyList()
+  private var authenticatedAtLoad: Boolean = false
+
   init {
-    viewModelScope.launch {
-      allTags =
-        runSuspendCatching<ImmutableList<Tag>> {
-            withContext(ioDispatcher) {
-              when (val result = api.getTags()) {
-                is Success -> result.value.toImmutableList()
-                is Failure.NetworkFailure -> throw result.error
-                is Failure.UnknownFailure -> throw result.error
-                is Failure.HttpFailure -> throw result.toError()
-                is Failure.ApiFailure -> throw IOException("API returned an invalid response")
-              }
-            }
-          }
-          .fold(
-            success = { details -> NetworkState.Success(details) },
-            failure = { NetworkState.Error(error = it, description = "Failed to load comments") },
-          )
-    }
+    viewModelScope.launch { loadTags() }
   }
 
   fun saveTagBlock(tag: String, expirationMillis: Long?) {
-    viewModelScope.launch { tagBlockRepository.saveTagBlock(tag, expirationMillis) }
+    setDraft(tagBlocks.value.filterNot { it.tag == tag } + TagBlock(tag, expirationMillis))
   }
 
   fun removeTagBlock(tag: String) {
-    viewModelScope.launch { tagBlockRepository.removeTagBlock(tag) }
+    setDraft(tagBlocks.value.filterNot { it.tag == tag })
+  }
+
+  fun discardChanges() {
+    setDraft(initialBlocks)
+    saveError = null
+  }
+
+  fun save() {
+    if (!isDirty || isSaving) return
+    viewModelScope.launch {
+      isSaving = true
+      saveError = null
+      val result = runSuspendCatching { withContext(ioDispatcher) { persistDraft() } }
+      result.fold(
+        success = {
+          isSaving = false
+        },
+        failure = {
+          isSaving = false
+          saveError = it.message ?: "Failed to save tag filters"
+        },
+      )
+    }
   }
 
   fun triggerCleanupNow() {
     viewModelScope.launch { tagBlockRepository.removeExpiredTags() }
   }
+
+  private suspend fun loadTags() {
+    allTags = NetworkState.Loading
+    allTags =
+      runSuspendCatching<ImmutableList<Tag>> { withContext(ioDispatcher) { loadTagsInternal() } }
+        .fold(
+          success = { details -> NetworkState.Success(details) },
+          failure = { NetworkState.Error(error = it, description = "Failed to load tags") },
+        )
+  }
+
+  private suspend fun loadTagsInternal(): ImmutableList<Tag> {
+    val startedAuthenticated = sessionCookieStore.getUsername() != null
+    authenticatedAtLoad = startedAuthenticated
+    val page =
+      when (val result = api.getFilters()) {
+        is Success -> result.value
+        is Failure.NetworkFailure -> throw result.error
+        is Failure.UnknownFailure -> throw result.error
+        is Failure.HttpFailure -> throw result.toError()
+        is Failure.ApiFailure -> throw IOException("API returned an invalid response")
+      }
+    val currentBlocks = tagBlockRepository.getTagBlocks().first().normalized()
+    val shouldUseRemoteState = startedAuthenticated && sessionCookieStore.getUsername() != null
+    val mergedBlocks =
+      if (shouldUseRemoteState) {
+        val temporaryRows =
+          currentBlocks
+            .filterNot { it.isPermanent || it.tag in page.blockedTags }
+            .sortedBy { it.tag }
+        (page.blockedTags.map { TagBlock(it, null) } + temporaryRows).normalized()
+      } else {
+        authenticatedAtLoad = false
+        currentBlocks
+      }
+    if (shouldUseRemoteState) {
+      tagBlockRepository.replaceTagBlocks(mergedBlocks)
+    }
+    initialBlocks = mergedBlocks
+    setDraft(mergedBlocks)
+    return page.tags.toImmutableList()
+  }
+
+  private suspend fun persistDraft() {
+    val draft = tagBlocks.value.normalized()
+    if (!authenticatedAtLoad) {
+      tagBlockRepository.replaceTagBlocks(draft)
+      initialBlocks = draft
+      isDirty = false
+      return
+    }
+
+    val permanentTags = draft.filter { it.isPermanent }.mapTo(mutableSetOf()) { it.tag }
+    val temporaryRows = draft.filterNot { it.isPermanent }
+    val remoteCanonical =
+      when (val result = authenticatedApi.saveBlockedTags(permanentTags)) {
+        is Success -> result.value
+        is Failure.NetworkFailure -> throw result.error
+        is Failure.UnknownFailure -> throw result.error
+        is Failure.HttpFailure -> throw result.toError()
+        is Failure.ApiFailure -> throw IOException("API returned an invalid response")
+      }
+    val finalBlocks =
+      (remoteCanonical.map { TagBlock(it, null) } +
+          temporaryRows.filterNot { it.tag in remoteCanonical })
+        .normalized()
+    tagBlockRepository.replaceTagBlocks(finalBlocks)
+    initialBlocks = finalBlocks
+    setDraft(initialBlocks)
+  }
+
+  private fun setDraft(blocks: List<TagBlock>) {
+    val normalized = blocks.normalized()
+    tagBlocks.value = normalized
+    isDirty = normalized != initialBlocks
+  }
+
+  private fun List<TagBlock>.normalized(): List<TagBlock> =
+    distinctBy { it.tag }.sortedBy { it.tag }
 }

--- a/common/src/main/kotlin/dev/msfjarvis/claw/common/tags/TagList.kt
+++ b/common/src/main/kotlin/dev/msfjarvis/claw/common/tags/TagList.kt
@@ -6,6 +6,7 @@
  */
 package dev.msfjarvis.claw.common.tags
 
+import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -24,6 +25,7 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.AccessTime
 import androidx.compose.material.icons.filled.Block
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.DatePicker
 import androidx.compose.material3.DatePickerDialog
 import androidx.compose.material3.ExperimentalMaterial3Api
@@ -63,6 +65,7 @@ import kotlinx.datetime.toLocalDateTime
 @Composable
 fun TagList(
   contentPadding: PaddingValues,
+  popBackStack: () -> Unit,
   modifier: Modifier = Modifier,
   viewModel: TagFilterViewModel = metroViewModel(key = "tag_filter"),
 ) {
@@ -71,6 +74,32 @@ fun TagList(
   val tagBlocks by viewModel.tagBlocks.collectAsStateWithLifecycle(emptyList())
   var showDatePicker by remember { mutableStateOf(false) }
   var selectedTagForDatePicker by remember { mutableStateOf<String?>(null) }
+  var showDiscardDialog by remember { mutableStateOf(false) }
+
+  BackHandler(enabled = viewModel.isDirty) { showDiscardDialog = true }
+
+  if (showDiscardDialog) {
+    AlertDialog(
+      onDismissRequest = { showDiscardDialog = false },
+      title = { Text(stringResource(R.string.discard_tag_filter_changes_title)) },
+      text = { Text(stringResource(R.string.discard_tag_filter_changes_message)) },
+      confirmButton = {
+        TextButton(
+          onClick = {
+            viewModel.discardChanges()
+            showDiscardDialog = false
+          }
+        ) {
+          Text(stringResource(R.string.discard_changes))
+        }
+      },
+      dismissButton = {
+        TextButton(onClick = { showDiscardDialog = false }) {
+          Text(stringResource(R.string.keep_editing))
+        }
+      },
+    )
+  }
 
   selectedTagForDatePicker?.let { tagName ->
     if (showDatePicker) {
@@ -133,6 +162,24 @@ fun TagList(
       Column(
         modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp).padding(contentPadding)
       ) {
+        Row(
+          modifier = Modifier.fillMaxWidth(),
+          horizontalArrangement = Arrangement.End,
+        ) {
+          TextButton(
+            enabled = viewModel.isDirty && !viewModel.isSaving,
+            onClick = {
+              viewModel.save()
+              popBackStack()
+            },
+          ) {
+            Text(
+              stringResource(
+                if (viewModel.isSaving) R.string.saving_tag_filters else R.string.save_tag_filters
+              )
+            )
+          }
+        }
         if (BuildConfig.DEBUG) {
           TagExpirationTestControls(onTriggerCleanup = { viewModel.triggerCleanupNow() })
         }
@@ -141,6 +188,14 @@ fun TagList(
           style = MaterialTheme.typography.bodyMedium,
           color = MaterialTheme.colorScheme.onBackground,
         )
+        viewModel.saveError?.let {
+          Text(
+            text = stringResource(R.string.failed_to_save_tag_filters),
+            style = MaterialTheme.typography.bodySmall,
+            color = MaterialTheme.colorScheme.error,
+            modifier = Modifier.padding(top = 8.dp),
+          )
+        }
         FlexBox(
           modifier = modifier.fillMaxWidth().verticalScroll(rememberScrollState()),
           config = {

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -8,6 +8,9 @@
   <string name="block_until">Block Until</string>
   <string name="block_forever">Block Forever</string>
   <string name="failed_to_load_tags">Failed to load tags</string>
+  <string name="save_tag_filters">Save</string>
+  <string name="saving_tag_filters">Saving…</string>
+  <string name="failed_to_save_tag_filters">Failed to save tag filters</string>
   <string name="posts_with_selected_tags_will_be_filtere">Posts with selected tags will be filtered out of hottest/newest/search feeds</string>
   <string name="expirationmillis"> • %1$s</string>
   <string name="debug_controls">Debug Controls</string>
@@ -27,4 +30,8 @@
   <string name="in_reply_to">In reply to</string>
   <string name="quote">Quote</string>
   <string name="cancel">Cancel</string>
+  <string name="discard_tag_filter_changes_title">Discard tag filter changes?</string>
+  <string name="discard_tag_filter_changes_message">Your unsaved tag filter changes will be lost.</string>
+  <string name="discard_changes">Discard</string>
+  <string name="keep_editing">Keep editing</string>
 </resources>

--- a/common/src/test/kotlin/dev/msfjarvis/claw/common/comments/reply/ReplyViewModelTest.kt
+++ b/common/src/test/kotlin/dev/msfjarvis/claw/common/comments/reply/ReplyViewModelTest.kt
@@ -13,6 +13,7 @@ import com.slack.eithernet.ApiResult
 import dev.msfjarvis.claw.api.AuthenticatedLobstersApi
 import dev.msfjarvis.claw.api.LobstersApi
 import dev.msfjarvis.claw.model.CSRFToken
+import dev.msfjarvis.claw.model.FiltersPage
 import dev.msfjarvis.claw.model.LobstersPost
 import dev.msfjarvis.claw.model.LobstersPostDetails
 import dev.msfjarvis.claw.model.ReplyForm
@@ -124,6 +125,14 @@ private class FakeLobstersApi(
     ApiResult.success(CSRFToken("csrf"))
 
   override suspend fun getTags(): ApiResult<List<Tag>, Unit> = error("unused")
+
+  override suspend fun getFilters(): ApiResult<FiltersPage, Unit> = error("unused")
+
+  override suspend fun saveFilters(
+    authenticityToken: String,
+    tags: Map<String, String>,
+    commit: String,
+  ): ApiResult<Unit, Unit> = error("unused")
 
   override suspend fun upvoteComment(
     commentId: String,

--- a/common/src/test/kotlin/dev/msfjarvis/claw/common/tags/TagBlockRepositoryTest.kt
+++ b/common/src/test/kotlin/dev/msfjarvis/claw/common/tags/TagBlockRepositoryTest.kt
@@ -10,6 +10,8 @@ import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
 import com.google.common.truth.Truth.assertThat
 import dev.msfjarvis.claw.database.LobstersDatabase
 import dev.msfjarvis.claw.database.local.TagBlocksQueries
+import dev.msfjarvis.claw.model.TagBlock
+import kotlin.time.Clock
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.take
@@ -43,7 +45,7 @@ class TagBlockRepositoryTest {
     val testDispatcher = StandardTestDispatcher(testScheduler)
     val repository = TagBlockRepository(tagBlocksQueries, testDispatcher, testDispatcher)
 
-    val expirationTime = System.currentTimeMillis() + 86400000
+    val expirationTime = Clock.System.now().toEpochMilliseconds() + 86400000
     repository.saveTagBlock("android", expirationTime)
     val tags = repository.getSavedTags().first()
     assertThat(tags).containsExactly("android")
@@ -69,10 +71,10 @@ class TagBlockRepositoryTest {
 
     val repository = TagBlockRepository(tagBlocksQueries, testDispatcher, testDispatcher)
 
-    val firstExpiration = System.currentTimeMillis() + 86400000
+    val firstExpiration = Clock.System.now().toEpochMilliseconds() + 86400000
     repository.saveTagBlock("rust", firstExpiration)
 
-    val secondExpiration = System.currentTimeMillis() + 172800000
+    val secondExpiration = Clock.System.now().toEpochMilliseconds() + 172800000
     repository.saveTagBlock("rust", secondExpiration)
 
     val tagBlocks = repository.getTagBlocks().first()
@@ -84,7 +86,7 @@ class TagBlockRepositoryTest {
   fun `replaceTagBlocks replaces permanent with temporary block`() = runTest {
     val testDispatcher = StandardTestDispatcher(testScheduler)
     val repository = TagBlockRepository(tagBlocksQueries, testDispatcher, testDispatcher)
-    val expiration = System.currentTimeMillis() + 86_400_000
+    val expiration = Clock.System.now().toEpochMilliseconds() + 86_400_000
 
     repository.saveTagBlock("kotlin", null)
     repository.replaceTagBlocks(listOf(TagBlock("kotlin", expiration)))
@@ -98,7 +100,7 @@ class TagBlockRepositoryTest {
   fun `replaceTagBlocks replaces temporary with permanent block`() = runTest {
     val testDispatcher = StandardTestDispatcher(testScheduler)
     val repository = TagBlockRepository(tagBlocksQueries, testDispatcher, testDispatcher)
-    val expiration = System.currentTimeMillis() + 86_400_000
+    val expiration = Clock.System.now().toEpochMilliseconds() + 86_400_000
 
     repository.saveTagBlock("kotlin", expiration)
     repository.replaceTagBlocks(listOf(TagBlock("kotlin", null)))
@@ -144,8 +146,8 @@ class TagBlockRepositoryTest {
 
     val repository = TagBlockRepository(tagBlocksQueries, testDispatcher, testDispatcher)
 
-    val pastTime = System.currentTimeMillis() - 1000
-    val futureTime = System.currentTimeMillis() + 86400000
+    val pastTime = Clock.System.now().toEpochMilliseconds() - 1000
+    val futureTime = Clock.System.now().toEpochMilliseconds() + 86400000
 
     repository.saveTagBlock("expired-tag", pastTime)
     repository.saveTagBlock("active-tag", futureTime)
@@ -183,8 +185,8 @@ class TagBlockRepositoryTest {
 
     val repository = TagBlockRepository(tagBlocksQueries, testDispatcher, testDispatcher)
 
-    val pastTime = System.currentTimeMillis() - 1000
-    val futureTime = System.currentTimeMillis() + 86400000
+    val pastTime = Clock.System.now().toEpochMilliseconds() - 1000
+    val futureTime = Clock.System.now().toEpochMilliseconds() + 86400000
 
     repository.saveTagBlock("expired", pastTime)
     repository.saveTagBlock("active", futureTime)
@@ -227,8 +229,8 @@ class TagBlockRepositoryTest {
 
     val repository = TagBlockRepository(tagBlocksQueries, testDispatcher, testDispatcher)
 
-    val pastTime = System.currentTimeMillis() - 1000
-    val futureTime = System.currentTimeMillis() + 86400000
+    val pastTime = Clock.System.now().toEpochMilliseconds() - 1000
+    val futureTime = Clock.System.now().toEpochMilliseconds() + 86400000
 
     repository.saveTagBlock("expired1", pastTime)
     repository.saveTagBlock("expired2", pastTime - 5000)

--- a/common/src/test/kotlin/dev/msfjarvis/claw/common/tags/TagBlockRepositoryTest.kt
+++ b/common/src/test/kotlin/dev/msfjarvis/claw/common/tags/TagBlockRepositoryTest.kt
@@ -81,6 +81,46 @@ class TagBlockRepositoryTest {
   }
 
   @Test
+  fun `replaceTagBlocks replaces permanent with temporary block`() = runTest {
+    val testDispatcher = StandardTestDispatcher(testScheduler)
+    val repository = TagBlockRepository(tagBlocksQueries, testDispatcher, testDispatcher)
+    val expiration = System.currentTimeMillis() + 86_400_000
+
+    repository.saveTagBlock("kotlin", null)
+    repository.replaceTagBlocks(listOf(TagBlock("kotlin", expiration)))
+
+    val block = repository.getTagBlocks().first().single()
+    assertThat(block.tag).isEqualTo("kotlin")
+    assertThat(block.expirationMillis).isEqualTo(expiration)
+  }
+
+  @Test
+  fun `replaceTagBlocks replaces temporary with permanent block`() = runTest {
+    val testDispatcher = StandardTestDispatcher(testScheduler)
+    val repository = TagBlockRepository(tagBlocksQueries, testDispatcher, testDispatcher)
+    val expiration = System.currentTimeMillis() + 86_400_000
+
+    repository.saveTagBlock("kotlin", expiration)
+    repository.replaceTagBlocks(listOf(TagBlock("kotlin", null)))
+
+    val block = repository.getTagBlocks().first().single()
+    assertThat(block.isPermanent).isTrue()
+  }
+
+  @Test
+  fun `replaceTagBlocks removes rows omitted from replacement set`() = runTest {
+    val testDispatcher = StandardTestDispatcher(testScheduler)
+    val repository = TagBlockRepository(tagBlocksQueries, testDispatcher, testDispatcher)
+
+    repository.saveTagBlock("old", null)
+    repository.saveTagBlock("kept", null)
+
+    repository.replaceTagBlocks(listOf(TagBlock("kept", null)))
+
+    assertThat(repository.getTagBlocks().first().map { it.tag }).containsExactly("kept")
+  }
+
+  @Test
   fun `removeTagBlock deletes tag successfully`() = runTest {
     val testDispatcher = StandardTestDispatcher(testScheduler)
 
@@ -162,7 +202,7 @@ class TagBlockRepositoryTest {
 
     val repository = TagBlockRepository(tagBlocksQueries, testDispatcher, testDispatcher)
     val emissions = mutableListOf<List<String>>()
-    val collectedBlocks = mutableListOf<List<dev.msfjarvis.claw.model.TagBlock>>()
+    val collectedBlocks = mutableListOf<List<TagBlock>>()
 
     val collector =
       backgroundScope.launch(testDispatcher) {

--- a/common/src/test/kotlin/dev/msfjarvis/claw/common/tags/TagFilterViewModelTest.kt
+++ b/common/src/test/kotlin/dev/msfjarvis/claw/common/tags/TagFilterViewModelTest.kt
@@ -1,0 +1,349 @@
+/*
+ * Copyright © Harsh Shandilya.
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package dev.msfjarvis.claw.common.tags
+
+import app.cash.sqldelight.driver.jdbc.sqlite.JdbcSqliteDriver
+import com.google.common.truth.Truth.assertThat
+import com.slack.eithernet.ApiResult
+import dev.msfjarvis.claw.api.AuthenticatedLobstersApi
+import dev.msfjarvis.claw.api.LobstersApi
+import dev.msfjarvis.claw.core.network.SessionCookieStore
+import dev.msfjarvis.claw.database.LobstersDatabase
+import dev.msfjarvis.claw.database.local.TagBlocksQueries
+import dev.msfjarvis.claw.model.CSRFToken
+import dev.msfjarvis.claw.model.FiltersPage
+import dev.msfjarvis.claw.model.LobstersPost
+import dev.msfjarvis.claw.model.LobstersPostDetails
+import dev.msfjarvis.claw.model.ReplyForm
+import dev.msfjarvis.claw.model.Tag
+import dev.msfjarvis.claw.model.User
+import java.io.IOException
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.test.StandardTestDispatcher
+import kotlinx.coroutines.test.advanceUntilIdle
+import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
+import kotlinx.coroutines.test.setMain
+import okhttp3.MultipartBody
+import org.junit.jupiter.api.AfterEach
+import org.junit.jupiter.api.BeforeEach
+import org.junit.jupiter.api.Test
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class TagFilterViewModelTest {
+  private val dispatcher = StandardTestDispatcher()
+  private lateinit var driver: JdbcSqliteDriver
+  private lateinit var tagBlocksQueries: TagBlocksQueries
+
+  @BeforeEach
+  fun setUp() {
+    Dispatchers.setMain(dispatcher)
+    driver = JdbcSqliteDriver(JdbcSqliteDriver.IN_MEMORY)
+    LobstersDatabase.Schema.create(driver)
+    tagBlocksQueries = TagBlocksQueries(driver)
+  }
+
+  @AfterEach
+  fun tearDown() {
+    Dispatchers.resetMain()
+    driver.close()
+  }
+
+  @Test
+  fun `chip mutation updates draft without writing repository until save`() =
+    runTest(dispatcher) {
+      val repository = repository()
+      repository.saveTagBlock("existing", null)
+      val api =
+        FakeTagFiltersApi(
+          filtersResponses = ArrayDeque(listOf(filtersPage(blockedTags = setOf("remote"))))
+        )
+      val viewModel =
+        TagFilterViewModel(
+          api = api,
+          authenticatedApi = AuthenticatedLobstersApi(api),
+          tagBlockRepository = repository,
+          sessionCookieStore = FakeSessionCookieStore(username = null),
+          ioDispatcher = dispatcher,
+        )
+      advanceUntilIdle()
+
+      viewModel.saveTagBlock("draft", null)
+      advanceUntilIdle()
+
+      assertThat(viewModel.filteredTags.value).containsExactly("draft", "existing")
+      assertThat(viewModel.tagBlocks.value.map { it.tag }).containsExactly("draft", "existing")
+      assertThat(repository.getTagBlocks().first().map { it.tag }).containsExactly("existing")
+      assertThat(viewModel.isDirty).isTrue()
+
+      viewModel.save()
+      advanceUntilIdle()
+
+      assertThat(repository.getTagBlocks().first().map { it.tag })
+        .containsExactly("draft", "existing")
+      assertThat(viewModel.isDirty).isFalse()
+    }
+
+  @Test
+  fun `permanent block can be changed to temporary in draft`() =
+    runTest(dispatcher) {
+      val repository = repository()
+      repository.saveTagBlock("kotlin", null)
+      val api = FakeTagFiltersApi(filtersResponses = ArrayDeque(listOf(filtersPage())))
+      val viewModel = viewModel(repository, api, username = null)
+      advanceUntilIdle()
+
+      val expiration = 1_700_000_000_000L
+      viewModel.saveTagBlock("kotlin", expiration)
+
+      assertThat(viewModel.tagBlocks.value.single().expirationMillis).isEqualTo(expiration)
+      assertThat(repository.getTagBlocks().first().single().isPermanent).isTrue()
+    }
+
+  @Test
+  fun `temporary block can be changed to permanent in draft`() =
+    runTest(dispatcher) {
+      val repository = repository()
+      repository.saveTagBlock("kotlin", 1_700_000_000_000L)
+      val api = FakeTagFiltersApi(filtersResponses = ArrayDeque(listOf(filtersPage())))
+      val viewModel = viewModel(repository, api, username = null)
+      advanceUntilIdle()
+
+      viewModel.saveTagBlock("kotlin", null)
+
+      assertThat(viewModel.tagBlocks.value.single().isPermanent).isTrue()
+      assertThat(repository.getTagBlocks().first().single().isPermanent).isFalse()
+    }
+
+  @Test
+  fun `authenticated load overlays remote permanent rows and keeps non conflicting local temporary rows`() =
+    runTest(dispatcher) {
+      val repository = repository()
+      repository.saveTagBlock("android", 1_700_000_000_000L)
+      repository.saveTagBlock("conflict", 1_800_000_000_000L)
+      val api =
+        FakeTagFiltersApi(
+          filtersResponses =
+            ArrayDeque(listOf(filtersPage(blockedTags = setOf("kotlin", "conflict"))))
+        )
+
+      val viewModel = viewModel(repository, api, username = "msfjarvis")
+      advanceUntilIdle()
+
+      assertThat(viewModel.filteredTags.value).containsExactly("android", "conflict", "kotlin")
+      assertThat(viewModel.tagBlocks.value.map { it.tag to it.expirationMillis })
+        .containsExactly(
+          "android" to 1_700_000_000_000L,
+          "conflict" to null,
+          "kotlin" to null,
+        )
+      assertThat(repository.getTagBlocks().first().map { it.tag to it.expirationMillis })
+        .containsExactly(
+          "android" to 1_700_000_000_000L,
+          "conflict" to null,
+          "kotlin" to null,
+        )
+    }
+
+  @Test
+  fun `logged out load ignores checked remote rows`() =
+    runTest(dispatcher) {
+      val repository = repository()
+      repository.saveTagBlock("local", null)
+      val api =
+        FakeTagFiltersApi(
+          filtersResponses = ArrayDeque(listOf(filtersPage(blockedTags = setOf("remote"))))
+        )
+
+      val viewModel = viewModel(repository, api, username = null)
+      advanceUntilIdle()
+
+      assertThat(viewModel.filteredTags.value).containsExactly("local")
+      assertThat(repository.getTagBlocks().first().map { it.tag }).containsExactly("local")
+    }
+
+  @Test
+  fun `authenticated save sends only permanent tags and preserves non conflicting temporary rows locally`() =
+    runTest(dispatcher) {
+      val repository = repository()
+      val api =
+        FakeTagFiltersApi(
+          filtersResponses =
+            ArrayDeque(
+              listOf(
+                filtersPage(),
+                filtersPage(blockedTags = setOf("android", "kotlin")),
+                filtersPage(blockedTags = setOf("android", "kotlin")),
+              )
+            )
+        )
+      val viewModel = viewModel(repository, api, username = "msfjarvis")
+      advanceUntilIdle()
+
+      viewModel.saveTagBlock("android", null)
+      viewModel.saveTagBlock("kotlin", null)
+      viewModel.saveTagBlock("temporary", 1_900_000_000_000L)
+      advanceUntilIdle()
+
+      viewModel.save()
+      advanceUntilIdle()
+
+      assertThat(api.savedTags).containsExactly("tags[android]", "1", "tags[kotlin]", "1")
+      assertThat(repository.getTagBlocks().first().map { it.tag to it.expirationMillis })
+        .containsExactly(
+          "android" to null,
+          "kotlin" to null,
+          "temporary" to 1_900_000_000_000L,
+        )
+      assertThat(viewModel.isDirty).isFalse()
+    }
+
+  @Test
+  fun `failed save preserves dirty draft`() =
+    runTest(dispatcher) {
+      val repository = repository()
+      val api =
+        FakeTagFiltersApi(
+          filtersResponses = ArrayDeque(listOf(filtersPage(), filtersPage())),
+          saveFiltersResult = ApiResult.unknownFailure(IOException("boom")),
+        )
+      val viewModel = viewModel(repository, api, username = "msfjarvis")
+      advanceUntilIdle()
+
+      viewModel.saveTagBlock("kotlin", null)
+      advanceUntilIdle()
+      viewModel.save()
+      advanceUntilIdle()
+
+      assertThat(viewModel.isDirty).isTrue()
+      assertThat(viewModel.saveError).isEqualTo("boom")
+      assertThat(viewModel.filteredTags.value).containsExactly("kotlin")
+      assertThat(repository.getTagBlocks().first()).isEmpty()
+    }
+
+  private fun repository(): TagBlockRepository =
+    TagBlockRepository(tagBlocksQueries, dispatcher, dispatcher)
+
+  private fun viewModel(
+    repository: TagBlockRepository,
+    api: FakeTagFiltersApi,
+    username: String?,
+  ): TagFilterViewModel =
+    TagFilterViewModel(
+      api = api,
+      authenticatedApi = AuthenticatedLobstersApi(api),
+      tagBlockRepository = repository,
+      sessionCookieStore = FakeSessionCookieStore(username = username),
+      ioDispatcher = dispatcher,
+    )
+
+  private fun filtersPage(
+    blockedTags: Set<String> = emptySet(),
+    authenticityToken: String = "filters-token",
+  ): FiltersPage =
+    FiltersPage(
+      authenticityToken = authenticityToken,
+      tags =
+        listOf(
+          Tag(tag = "android", description = "Android"),
+          Tag(tag = "kotlin", description = "Kotlin"),
+        ),
+      blockedTags = blockedTags,
+    )
+}
+
+private class FakeSessionCookieStore(private var username: String?) : SessionCookieStore {
+  override fun get(): String? = null
+
+  override fun getUsername(): String? = username
+
+  override fun set(cookie: String, username: String) {
+    this.username = username
+  }
+
+  override fun clear() {
+    username = null
+  }
+
+  override fun isLoggedIn(): Flow<Boolean> = flowOf(username != null)
+
+  override fun username(): Flow<String?> = flowOf(username)
+}
+
+private class FakeTagFiltersApi(
+  private val filtersResponses: ArrayDeque<FiltersPage>,
+  private val saveFiltersResult: ApiResult<Unit, Unit> = ApiResult.success(Unit),
+) : LobstersApi {
+  var savedTags: Map<String, String>? = null
+    private set
+
+  override suspend fun getHottestPosts(page: Int): ApiResult<List<LobstersPost>, Unit> =
+    error("unused")
+
+  override suspend fun getNewestPosts(page: Int): ApiResult<List<LobstersPost>, Unit> =
+    error("unused")
+
+  override suspend fun getPostDetails(postId: String): ApiResult<LobstersPostDetails, Unit> =
+    error("unused")
+
+  override suspend fun getUser(username: String): ApiResult<User, Unit> = error("unused")
+
+  override suspend fun getCSRFToken(): ApiResult<CSRFToken, Unit> = error("unused")
+
+  override suspend fun getTags(): ApiResult<List<Tag>, Unit> = error("unused")
+
+  override suspend fun getFilters(): ApiResult<FiltersPage, Unit> =
+    ApiResult.success(filtersResponses.removeFirst())
+
+  override suspend fun saveFilters(
+    authenticityToken: String,
+    tags: Map<String, String>,
+    commit: String,
+  ): ApiResult<Unit, Unit> {
+    savedTags = tags
+    return saveFiltersResult
+  }
+
+  override suspend fun upvoteComment(
+    commentId: String,
+    csrfToken: String,
+    requestedWith: String,
+    reason: MultipartBody.Part,
+  ): ApiResult<Unit, Unit> = error("unused")
+
+  override suspend fun unvoteComment(
+    commentId: String,
+    csrfToken: String,
+    requestedWith: String,
+    reason: MultipartBody.Part,
+  ): ApiResult<Unit, Unit> = error("unused")
+
+  override suspend fun getReplyForm(
+    commentId: String,
+    csrfToken: String,
+    requestedWith: String,
+    referer: String,
+  ): ApiResult<ReplyForm, Unit> = error("unused")
+
+  override suspend fun postReply(
+    csrfToken: String,
+    requestedWith: String,
+    referer: String,
+    origin: String,
+    accept: String,
+    authenticityToken: MultipartBody.Part,
+    storyId: MultipartBody.Part,
+    method: MultipartBody.Part,
+    parentCommentShortId: MultipartBody.Part,
+    comment: MultipartBody.Part,
+    commit: MultipartBody.Part,
+  ): ApiResult<Unit, Unit> = error("unused")
+}

--- a/core/src/main/kotlin/dev/msfjarvis/claw/core/network/RetryAfterInterceptor.kt
+++ b/core/src/main/kotlin/dev/msfjarvis/claw/core/network/RetryAfterInterceptor.kt
@@ -10,6 +10,7 @@ import dev.zacsweers.metro.AppScope
 import dev.zacsweers.metro.ContributesIntoSet
 import dev.zacsweers.metro.Inject
 import java.util.concurrent.TimeUnit
+import kotlin.time.Clock
 import kotlinx.datetime.format.DateTimeComponents
 import okhttp3.Interceptor
 import okhttp3.Response
@@ -69,7 +70,8 @@ class RetryAfterInterceptor : Interceptor {
     }
 
     val retryInstant = parseHttpDate(retryAfter) ?: return 0
-    val delaySeconds = (retryInstant.toEpochMilliseconds() - System.currentTimeMillis()) / 1000
+    val delaySeconds =
+      (retryInstant.toEpochMilliseconds() - Clock.System.now().toEpochMilliseconds()) / 1000
     return if (delaySeconds > 0) delaySeconds.coerceAtMost(MAX_RETRY_DELAY_SECONDS) else 0
   }
 

--- a/model/src/commonMain/kotlin/dev/msfjarvis/claw/model/FiltersPage.kt
+++ b/model/src/commonMain/kotlin/dev/msfjarvis/claw/model/FiltersPage.kt
@@ -1,0 +1,13 @@
+/*
+ * Copyright © Harsh Shandilya.
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package dev.msfjarvis.claw.model
+
+class FiltersPage(
+  val authenticityToken: String,
+  val tags: List<Tag>,
+  val blockedTags: Set<String>,
+)

--- a/zipline-parser-api/src/commonMain/kotlin/dev/msfjarvis/claw/parser/model/ParserModels.kt
+++ b/zipline-parser-api/src/commonMain/kotlin/dev/msfjarvis/claw/parser/model/ParserModels.kt
@@ -73,3 +73,9 @@ class ReplyForm(
   val method: String,
   val parentCommentShortId: String,
 )
+
+class FiltersPage(
+  val authenticityToken: String,
+  val tags: List<Tag>,
+  val blockedTags: Set<String>,
+)

--- a/zipline-parser-api/src/commonMain/kotlin/dev/msfjarvis/claw/parser/model/ParserSerializers.kt
+++ b/zipline-parser-api/src/commonMain/kotlin/dev/msfjarvis/claw/parser/model/ParserSerializers.kt
@@ -23,6 +23,7 @@ val ParserSerializersModule: SerializersModule = SerializersModule {
   contextual(Tag::class, TagSerializer)
   contextual(CSRFToken::class, CSRFTokenSerializer)
   contextual(ReplyForm::class, ReplyFormSerializer)
+  contextual(FiltersPage::class, FiltersPageSerializer)
 }
 
 internal object LobstersPostSerializer : KSerializer<LobstersPost> {
@@ -199,21 +200,24 @@ internal object TagSerializer : KSerializer<Tag> {
     PrimitiveSerialDescriptor("dev.msfjarvis.claw.parser.model.Tag", PrimitiveKind.STRING)
 
   override fun serialize(encoder: Encoder, value: Tag) {
-    encoder.encodeString(
-      PacketWriter()
-        .string(value.tag)
-        .string(value.description)
-        .boolean(value.privileged)
-        .boolean(value.active)
-        .string(value.category)
-        .boolean(value.isMedia)
-        .double(value.hotnessMod)
-        .build()
-    )
+    encoder.encodeString(toPayload(value))
   }
 
-  override fun deserialize(decoder: Decoder): Tag {
-    val reader = PacketReader(decoder.decodeString())
+  override fun deserialize(decoder: Decoder): Tag = fromPayload(decoder.decodeString())
+
+  fun toPayload(value: Tag): String =
+    PacketWriter()
+      .string(value.tag)
+      .string(value.description)
+      .boolean(value.privileged)
+      .boolean(value.active)
+      .string(value.category)
+      .boolean(value.isMedia)
+      .double(value.hotnessMod)
+      .build()
+
+  fun fromPayload(payload: String): Tag {
+    val reader = PacketReader(payload)
     return Tag(
       tag = reader.string(),
       description = reader.string(),
@@ -259,6 +263,36 @@ internal object ReplyFormSerializer : KSerializer<ReplyForm> {
       storyId = reader.string(),
       method = reader.string(),
       parentCommentShortId = reader.string(),
+    )
+  }
+}
+
+internal object FiltersPageSerializer : KSerializer<FiltersPage> {
+  override val descriptor: SerialDescriptor =
+    PrimitiveSerialDescriptor("dev.msfjarvis.claw.parser.model.FiltersPage", PrimitiveKind.STRING)
+
+  override fun serialize(encoder: Encoder, value: FiltersPage) {
+    encoder.encodeString(
+      PacketWriter()
+        .string(value.authenticityToken)
+        .int(value.tags.size)
+        .apply { value.tags.forEach { string(TagSerializer.toPayload(it)) } }
+        .stringList(value.blockedTags.sorted())
+        .build()
+    )
+  }
+
+  override fun deserialize(decoder: Decoder): FiltersPage {
+    val reader = PacketReader(decoder.decodeString())
+    val authenticityToken = reader.string()
+    val tags =
+      List(reader.int()) {
+        TagSerializer.fromPayload(reader.string())
+      }
+    return FiltersPage(
+      authenticityToken = authenticityToken,
+      tags = tags,
+      blockedTags = reader.stringList().toSet(),
     )
   }
 }

--- a/zipline-parser/api/zipline-api.toml
+++ b/zipline-parser/api/zipline-api.toml
@@ -7,6 +7,9 @@ functions = [
   # fun parseCsrfToken(kotlin.String): dev.msfjarvis.claw.parser.model.CSRFToken
   "XO8wcclo",
 
+  # fun parseFiltersPage(kotlin.String): dev.msfjarvis.claw.parser.model.FiltersPage
+  "wMkF4F2r",
+
   # fun parsePostDetails(kotlin.String): dev.msfjarvis.claw.parser.model.LobstersPostDetails
   "K6Im4ZQe",
 

--- a/zipline-parser/src/commonMain/kotlin/dev/msfjarvis/claw/parser/LobstersParserService.kt
+++ b/zipline-parser/src/commonMain/kotlin/dev/msfjarvis/claw/parser/LobstersParserService.kt
@@ -8,6 +8,7 @@ package dev.msfjarvis.claw.parser
 
 import app.cash.zipline.ZiplineService
 import dev.msfjarvis.claw.parser.model.CSRFToken
+import dev.msfjarvis.claw.parser.model.FiltersPage
 import dev.msfjarvis.claw.parser.model.LobstersPost
 import dev.msfjarvis.claw.parser.model.LobstersPostDetails
 import dev.msfjarvis.claw.parser.model.ReplyForm
@@ -28,4 +29,6 @@ interface LobstersParserService : ZiplineService {
   fun parseCsrfToken(html: String): CSRFToken
 
   fun parseReplyForm(html: String): ReplyForm
+
+  fun parseFiltersPage(html: String): FiltersPage
 }

--- a/zipline-parser/src/commonMain/kotlin/dev/msfjarvis/claw/parser/LobstersParserServiceImpl.kt
+++ b/zipline-parser/src/commonMain/kotlin/dev/msfjarvis/claw/parser/LobstersParserServiceImpl.kt
@@ -7,6 +7,7 @@
 package dev.msfjarvis.claw.parser
 
 import dev.msfjarvis.claw.parser.internal.parseCsrfToken as parseCsrfTokenHtml
+import dev.msfjarvis.claw.parser.internal.parseFiltersPage as parseFiltersPageHtml
 import dev.msfjarvis.claw.parser.internal.parsePostDetails as parsePostDetailsHtml
 import dev.msfjarvis.claw.parser.internal.parsePostsPage as parsePostsPageHtml
 import dev.msfjarvis.claw.parser.internal.parseReplyForm as parseReplyFormHtml
@@ -14,6 +15,7 @@ import dev.msfjarvis.claw.parser.internal.parseSearchResults as parseSearchResul
 import dev.msfjarvis.claw.parser.internal.parseTagsPage as parseTagsPageHtml
 import dev.msfjarvis.claw.parser.internal.parseUser as parseUserHtml
 import dev.msfjarvis.claw.parser.model.CSRFToken
+import dev.msfjarvis.claw.parser.model.FiltersPage
 import dev.msfjarvis.claw.parser.model.LobstersPost
 import dev.msfjarvis.claw.parser.model.LobstersPostDetails
 import dev.msfjarvis.claw.parser.model.ReplyForm
@@ -34,4 +36,6 @@ class LobstersParserServiceImpl : LobstersParserService {
   override fun parseCsrfToken(html: String): CSRFToken = parseCsrfTokenHtml(html)
 
   override fun parseReplyForm(html: String): ReplyForm = parseReplyFormHtml(html)
+
+  override fun parseFiltersPage(html: String): FiltersPage = parseFiltersPageHtml(html)
 }

--- a/zipline-parser/src/commonMain/kotlin/dev/msfjarvis/claw/parser/internal/TagParsers.kt
+++ b/zipline-parser/src/commonMain/kotlin/dev/msfjarvis/claw/parser/internal/TagParsers.kt
@@ -8,10 +8,42 @@ package dev.msfjarvis.claw.parser.internal
 
 import com.fleeksoft.ksoup.Ksoup
 import com.fleeksoft.ksoup.nodes.Element
+import dev.msfjarvis.claw.parser.model.FiltersPage
 import dev.msfjarvis.claw.parser.model.Tag
 
 internal fun parseTagsPage(html: String): List<Tag> {
   return Ksoup.parse(html, baseUri = BASE_URL).select("ol.category_tags > li").map(::parseTag)
+}
+
+internal fun parseFiltersPage(html: String): FiltersPage {
+  val document = Ksoup.parse(html, baseUri = BASE_URL)
+  val authenticityToken =
+    document.select("input[name=authenticity_token]").firstOrNull()?.attr("value").orEmpty()
+  val blockedTags =
+    document
+      .select("input[type=checkbox][name^='tags[']")
+      .filter { it.hasAttr("checked") }
+      .mapNotNull {
+        it.attr("name").removePrefix("tags[").removeSuffix("]").takeIf(String::isNotBlank)
+      }
+      .toSet()
+  val tags =
+    document.select("tr:has(input[type=checkbox][name^='tags['])").mapNotNull { row ->
+      val link = row.select("a.tag").firstOrNull() ?: return@mapNotNull null
+      val description = row.select("label span").firstOrNull()?.text().orEmpty()
+      Tag(
+        tag = link.text(),
+        description = description,
+        privileged = row.attr("data-privileged").toBoolean(),
+        active =
+          !row.select("label span").firstOrNull()?.classNames().orEmpty().contains("inactive_tag"),
+        category = row.attr("data-category"),
+        isMedia = link.classNames().contains("tag_is_media"),
+        hotnessMod = row.attr("data-hotness-mod").toDoubleOrNull() ?: 0.0,
+      )
+    }
+
+  return FiltersPage(authenticityToken = authenticityToken, tags = tags, blockedTags = blockedTags)
 }
 
 private fun parseTag(element: Element): Tag {

--- a/zipline-parser/src/jvmTest/kotlin/dev/msfjarvis/claw/parser/FiltersPageParserTest.kt
+++ b/zipline-parser/src/jvmTest/kotlin/dev/msfjarvis/claw/parser/FiltersPageParserTest.kt
@@ -1,0 +1,73 @@
+/*
+ * Copyright © Harsh Shandilya.
+ * Use of this source code is governed by an MIT-style
+ * license that can be found in the LICENSE file or at
+ * https://opensource.org/licenses/MIT.
+ */
+package dev.msfjarvis.claw.parser
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class FiltersPageParserTest {
+  private val service = LobstersParserServiceImpl()
+
+  @Test
+  fun parsesCheckedTagsAndMetadata() {
+    val page = service.parseFiltersPage(FILTERS_PAGE_HTML)
+
+    assertEquals("filters-token", page.authenticityToken)
+    assertEquals(setOf("kotlin"), page.blockedTags)
+    assertEquals(2, page.tags.size)
+
+    val kotlinTag = page.tags.first { it.tag == "kotlin" }
+    assertEquals("Kotlin discussions", kotlinTag.description)
+    assertEquals("language", kotlinTag.category)
+    assertTrue(kotlinTag.active)
+    assertFalse(kotlinTag.privileged)
+    assertFalse(kotlinTag.isMedia)
+    assertEquals(1.2, kotlinTag.hotnessMod)
+
+    val inactiveTag = page.tags.first { it.tag == "inactive" }
+    assertEquals("Inactive tag description", inactiveTag.description)
+    assertEquals("topic", inactiveTag.category)
+    assertFalse(inactiveTag.active)
+    assertTrue(inactiveTag.privileged)
+    assertTrue(inactiveTag.isMedia)
+    assertEquals(0.3, inactiveTag.hotnessMod)
+  }
+}
+
+private const val FILTERS_PAGE_HTML =
+  """
+  <!doctype html>
+  <html>
+    <body>
+      <form action="/filters" method="post">
+        <input type="hidden" name="authenticity_token" value="filters-token" />
+        <table>
+          <tr data-category="language" data-hotness-mod="1.2">
+            <td>
+              <label>
+                <input type="checkbox" name="tags[kotlin]" checked="checked" />
+                <a class="tag" href="/t/kotlin">kotlin</a>
+                <span>Kotlin discussions</span>
+              </label>
+            </td>
+          </tr>
+          <tr data-category="topic" data-privileged="true" data-hotness-mod="0.3">
+            <td>
+              <label>
+                <input type="checkbox" name="tags[inactive]" />
+                <a class="tag tag_is_media" href="/t/inactive">inactive</a>
+                <span class="inactive_tag">Inactive tag description</span>
+              </label>
+            </td>
+          </tr>
+        </table>
+      </form>
+    </body>
+  </html>
+  """


### PR DESCRIPTION
Now permanent tag blocks are propagated to Lobsters itself, and read back from the site which is considered the source of truth for permanent blocks. Lobsters has no concept of temporary blocks so that continues to be stored locally.

The older implementation has been kept as-is to facilitate users who aren't logged in.